### PR TITLE
added option to add content before input element of CheckBoxColumn

### DIFF
--- a/django_tables2/columns/checkboxcolumn.py
+++ b/django_tables2/columns/checkboxcolumn.py
@@ -5,7 +5,6 @@ from django_tables2.utils import AttributeDict
 import warnings
 from .base import Column, library
 
-
 @library.register
 class CheckBoxColumn(Column):
     """
@@ -38,6 +37,13 @@ class CheckBoxColumn(Column):
     - *input*     -- ``<input>`` elements in both ``<td>`` and ``<th>``.
     - *th__input* -- Replaces *input* attrs in header cells.
     - *td__input* -- Replaces *input* attrs in body cells.
+
+    .. attribute:: th__before_input
+
+        Is added to add content before the header input element:
+        ``'<th>'+th__before_input+'<input ...>``
+
+        :type: `unicode`
     """
     def __init__(self, attrs=None, **extra):
         # For backwards compatibility, passing in a normal dict effectively
@@ -60,6 +66,7 @@ class CheckBoxColumn(Column):
 
         kwargs = {b'orderable': False, b'attrs': attrs}
         kwargs.update(extra)
+        self.th__before_input = kwargs.pop('th__before_input','')
         super(CheckBoxColumn, self).__init__(**kwargs)
 
     @property
@@ -68,7 +75,7 @@ class CheckBoxColumn(Column):
         general = self.attrs.get('input')
         specific = self.attrs.get('th__input')
         attrs = AttributeDict(default, **(specific or general or {}))
-        return mark_safe('<input %s/>' % attrs.as_html())
+        return mark_safe(self.th__before_input+'<input %s/>' % attrs.as_html())
 
     def render(self, value, bound_column):  # pylint: disable=W0221
         default = {


### PR DESCRIPTION
I want to be able to do

    <th>title<input type="checkbox">

but can't add a the 'title'.

this commit allows to do this with:

    some_column = CheckBoxColumn(
            th__before_input='title',
    )
