### PR TITLE
Feature/multi table view

### DIFF
--- a/django_tables2/__init__.py
+++ b/django_tables2/__init__.py
@@ -7,7 +7,8 @@ from .columns import (BooleanColumn, Column, CheckBoxColumn, DateColumn,
 from .config  import RequestConfig
 from .utils   import A, Attrs
 try:
-    from .views   import SingleTableMixin, SingleTableView
+    from .views   import (SingleTableMixin, SingleTableView, MultiTableMixin,
+                          MultiTableView)
 except ImportError:
     pass
 

--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ImproperlyConfigured
 from django.views.generic import ListView, TemplateView
 from .config import RequestConfig
+import six
 
 
 class SingleTableMixin(object):
@@ -134,7 +135,7 @@ class MultiTableMixin(object):
         """
         table_classes = self.get_table_classes()
         tables = {}
-        for table_id, table_class in table_classes.iteritems():
+        for table_id, table_class in six.iteritems(table_classes):
             options = {}
             table = table_class(self.get_table_data(table_id))
             paginate = self.get_table_pagination(table_id)
@@ -150,8 +151,8 @@ class MultiTableMixin(object):
         """
         if self.table_classes:
             return self.table_classes
-        raise ImproperlyConfigured(u"Table classes were not specified. Define "
-                                   u"%(cls)s.table_classes"
+        raise ImproperlyConfigured("Table classes were not specified. Define "
+                                   "%(cls)s.table_classes"
                                    % {"cls": type(self).__name__})
 
     def get_context_table_name(self, table_id):
@@ -171,10 +172,10 @@ class MultiTableMixin(object):
             return getattr(self, 'get_%s_queryset' % table_id)()
         if table_id in self.table_models:
             return self.table_models[table_id].objects.all()
-        raise ImproperlyConfigured(u"Table data for %(table_id)s not specified. "
-                                   u"Define %(cls)s.table_data[%(table_id)s], "
-                                   u"%(cls)s.get_%(table_id)s_queryset(), or "
-                                   u"%(cls)s.table_models[%(table_id)s]."
+        raise ImproperlyConfigured("Table data for %(table_id)s not given. "
+                                   "Define %(cls)s.table_data[%(table_id)s], "
+                                   "%(cls)s.get_%(table_id)s_queryset(), or "
+                                   "%(cls)s.table_models[%(table_id)s]."
                                    % {
                                        "cls": type(self).__name__,
                                        "table_id": table_id,
@@ -197,7 +198,7 @@ class MultiTableMixin(object):
         tables = self.get_tables()
         context.update(dict(
             (self.get_context_table_name(table_id), table)
-            for table_id, table in tables.iteritems()
+            for table_id, table in six.iteritems(tables)
         ))
         return context
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -24,6 +24,11 @@ class SimpleTable(tables.Table):
         model = Region
 
 
+class SimpleTable2(tables.Table):
+    class Meta:
+        model = Region
+
+
 @views.test_if(USING_CBV)
 def view_should_support_pagination_options():
     for name in ("Queensland", "New South Wales", "Victoria", "Tasmania"):
@@ -40,7 +45,7 @@ def view_should_support_pagination_options():
 
 
 @views.test_if(USING_CBV)
-def should_support_explicit_table_data():
+def view_should_support_explicit_table_data():
     class SimpleView(DispatchHookMixin, tables.SingleTableView):
         table_class = SimpleTable
         table_data = [
@@ -54,3 +59,57 @@ def should_support_explicit_table_data():
     request = build_request('/')
     response, view = SimpleView.as_view()(request)
     assert view.get_table().paginator.num_pages == 3
+
+
+@views.test_if(USING_CBV)
+def multiview_should_support_pagination_options():
+    for name in ("Queensland", "New South Wales", "Victoria", "Tasmania"):
+        Region.objects.create(name=name)
+
+    class SimpleMultiView(DispatchHookMixin, tables.MultiTableView):
+        table_classes = {
+            'regions1': SimpleTable,
+            'regions2': SimpleTable2,
+        }
+        table_models = {
+            'regions1': Region,
+            'regions2': Region,
+        }
+        table_paginations = {
+            'regions1': {'per_page': 2},
+            # defaults to 'True' for non-specified
+        }
+        template_name = 'throwaway'  # needed for TemplateView
+
+    request = build_request('/')
+    response, view = SimpleMultiView.as_view()(request)
+    assert view.get_tables()['regions1'].paginator.num_pages == 2
+    assert view.get_tables()['regions2'].paginator.num_pages == 1
+
+
+@views.test_if(USING_CBV)
+def multiview_should_support_explicit_table_data():
+    class SimpleMultiView(DispatchHookMixin, tables.MultiTableView):
+        table_classes = {
+            'regions1': SimpleTable,
+            'regions2': SimpleTable2,
+        }
+        table_data = {
+            'regions1': [
+                {'name': 'Queensland'},
+                {'name': 'New South Wales'},
+                {'name': 'Victoria'},
+            ],
+            'regions2': [
+                {'name': 'Tasmania'},
+            ]
+        }
+        table_paginations = {
+            'regions1': {'per_page': 1},
+        }
+        template_name = 'throwaway'  # needed for TemplateView
+
+    request = build_request('/')
+    response, view = SimpleMultiView.as_view()(request)
+    assert view.get_tables()['regions1'].paginator.num_pages == 3
+    assert view.get_tables()['regions2'].paginator.num_pages == 1


### PR DESCRIPTION
Hi, this branch has an implementation of a `MultiTableView` with some basic tests. The tests and docstring should give a good idea of how to use the class - let me know if they don't.

I considered implementing validation that pagination query parameters for different tables on the same View don't collide. It seemed the implementation of this would be somewhat unwieldy... so I'm just deferring it to the user to define different `table.prefix` for each of the tables used in the View. This also allows for the (somewhat unusual) use case where you want multiple tables all synced to the same pagination parameters.

Let me know what you think. Cheers!
Mike