### PR TITLE
show_table_header attribute for Table class

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -478,7 +478,6 @@ class TableBase(object):
 
     @show_table_header.setter
     def show_table_header(self, value):
-        print "ketto"
         self._show_table_header = value
 
     @property

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -243,6 +243,7 @@ class TableOptions(object):
         self.per_page = getattr(options, "per_page", 25)
         self.per_page_field = getattr(options, "per_page_field", "per_page")
         self.prefix = getattr(options, "prefix", "")
+        self.show_table_header = getattr(options, "show_table_header", True)
         self.sequence = Sequence(getattr(options, "sequence", ()))
         if hasattr(options, "sortable"):
             warnings.warn("`Table.Meta.sortable` is deprecated, use `orderable` instead",
@@ -252,7 +253,6 @@ class TableOptions(object):
         self.template = getattr(options, "template", "django_tables2/table.html")
         self.localize = getattr(options, "localize", ())
         self.unlocalize = getattr(options, "unlocalize", ())
-
 
 class TableBase(object):
     """
@@ -335,6 +335,15 @@ class TableBase(object):
         :type: `unicode`
 
 
+    .. attribute:: show_table_header
+
+        If `False`, the table will not have a header (`<thead>`), default
+        value is `True`
+
+        :type: `bool`
+
+
+
     .. attribute:: prefix
 
         A prefix for querystring fields to avoid name-clashes when using
@@ -381,7 +390,8 @@ class TableBase(object):
     def __init__(self, data, order_by=None, orderable=None, empty_text=None,
                  exclude=None, attrs=None, sequence=None, prefix=None,
                  order_by_field=None, page_field=None, per_page_field=None,
-                 template=None, sortable=None, default=None, request=None):
+                 template=None, sortable=None, default=None, request=None,
+                 show_table_header=None):
         super(TableBase, self).__init__()
         self.exclude = exclude or ()
         self.sequence = sequence
@@ -402,6 +412,7 @@ class TableBase(object):
         self.order_by_field = order_by_field
         self.page_field = page_field
         self.per_page_field = per_page_field
+        self.show_table_header = show_table_header
         # Make a copy so that modifying this will not touch the class
         # definition. Note that this is different from forms, where the
         # copy is made available in a ``fields`` attribute.
@@ -459,6 +470,16 @@ class TableBase(object):
     @attrs.setter
     def attrs(self, value):
         self._attrs = value
+
+    @property
+    def show_table_header(self):
+        return (self._show_table_header if self._show_table_header is not None
+                                        else self._meta.show_table_header)
+
+    @show_table_header.setter
+    def show_table_header(self, value):
+        print "ketto"
+        self._show_table_header = value
 
     @property
     def empty_text(self):

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -243,7 +243,7 @@ class TableOptions(object):
         self.per_page = getattr(options, "per_page", 25)
         self.per_page_field = getattr(options, "per_page_field", "per_page")
         self.prefix = getattr(options, "prefix", "")
-        self.show_table_header = getattr(options, "show_table_header", True)
+        self.show_header = getattr(options, "show_header", True)
         self.sequence = Sequence(getattr(options, "sequence", ()))
         if hasattr(options, "sortable"):
             warnings.warn("`Table.Meta.sortable` is deprecated, use `orderable` instead",
@@ -335,7 +335,7 @@ class TableBase(object):
         :type: `unicode`
 
 
-    .. attribute:: show_table_header
+    .. attribute:: show_header
 
         If `False`, the table will not have a header (`<thead>`), default
         value is `True`
@@ -391,7 +391,7 @@ class TableBase(object):
                  exclude=None, attrs=None, sequence=None, prefix=None,
                  order_by_field=None, page_field=None, per_page_field=None,
                  template=None, sortable=None, default=None, request=None,
-                 show_table_header=None):
+                 show_header=None):
         super(TableBase, self).__init__()
         self.exclude = exclude or ()
         self.sequence = sequence
@@ -412,7 +412,7 @@ class TableBase(object):
         self.order_by_field = order_by_field
         self.page_field = page_field
         self.per_page_field = per_page_field
-        self.show_table_header = show_table_header
+        self.show_header = show_header
         # Make a copy so that modifying this will not touch the class
         # definition. Note that this is different from forms, where the
         # copy is made available in a ``fields`` attribute.
@@ -472,13 +472,13 @@ class TableBase(object):
         self._attrs = value
 
     @property
-    def show_table_header(self):
-        return (self._show_table_header if self._show_table_header is not None
-                                        else self._meta.show_table_header)
+    def show_header(self):
+        return (self._show_header if self._show_header is not None
+                else self._meta.show_header)
 
-    @show_table_header.setter
-    def show_table_header(self, value):
-        self._show_table_header = value
+    @show_header.setter
+    def show_header(self, value):
+        self._show_header = value
 
     @property
     def empty_text(self):

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -8,6 +8,7 @@
 <table{% if table.attrs %} {{ table.attrs.as_html }}{% endif %}>
     {% nospaceless %}
     {% block table.thead %}
+    {% if table.show_table_header %}
     <thead>
         <tr>
         {% for column in table.columns %}
@@ -19,6 +20,7 @@
         {% endfor %}
         </tr>
     </thead>
+    {% endif %}
     {% endblock table.thead %}
     {% block table.tbody %}
     <tbody>

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -8,7 +8,7 @@
 <table{% if table.attrs %} {{ table.attrs.as_html }}{% endif %}>
     {% nospaceless %}
     {% block table.thead %}
-    {% if table.show_table_header %}
+    {% if table.show_header %}
     <thead>
         <tr>
         {% for column in table.columns %}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -907,6 +907,19 @@ API Reference
             This functionality is also available via the ``empty_text`` keyword
             argument to a table's constructor.
 
+    .. attribute:: show_table_header
+
+        Defines whether the table header (``<thead>``) should be displayed or
+        not.
+
+        :type: `bool`
+        :default: `True`
+
+        .. note::
+
+            This functionality is also available via the ``show_table_header`` 
+            keyword argument to a table's constructor.
+
     .. attribute:: exclude
 
         Defines which columns should be excluded from the table. This is useful

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -907,7 +907,7 @@ API Reference
             This functionality is also available via the ``empty_text`` keyword
             argument to a table's constructor.
 
-    .. attribute:: show_table_header
+    .. attribute:: show_header
 
         Defines whether the table header (``<thead>``) should be displayed or
         not.
@@ -917,7 +917,7 @@ API Reference
 
         .. note::
 
-            This functionality is also available via the ``show_table_header`` 
+            This functionality is also available via the ``show_header`` 
             keyword argument to a table's constructor.
 
     .. attribute:: exclude

--- a/tests/templates.py
+++ b/tests/templates.py
@@ -85,7 +85,7 @@ def as_html():
     assert root.find('.//tbody/tr/td').text == 'this table is empty'
 
     # data without header
-    table = CountryTable(MEMORY_DATA, show_table_header=False)
+    table = CountryTable(MEMORY_DATA, show_header=False)
     root = parse(table.as_html())
     assert len(root.findall('.//thead')) == 0
     assert len(root.findall('.//tbody/tr')) == 4

--- a/tests/templates.py
+++ b/tests/templates.py
@@ -84,6 +84,13 @@ def as_html():
     assert int(root.find('.//tbody/tr/td').attrib['colspan']) == len(root.findall('.//thead/tr/th'))
     assert root.find('.//tbody/tr/td').text == 'this table is empty'
 
+    # data without header
+    table = CountryTable(MEMORY_DATA, show_table_header=False)
+    root = parse(table.as_html())
+    assert len(root.findall('.//thead')) == 0
+    assert len(root.findall('.//tbody/tr')) == 4
+    assert len(root.findall('.//tbody/tr/td')) == 16
+
     # with custom template
     table = CountryTable([], template="django_tables2/table.html")
     table.as_html()


### PR DESCRIPTION
Hide the table header (``<thead>``) quickly, without an extra template file.