### PR TITLE
Inherited Meta.fields overwrites custom column in base class

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -177,7 +177,7 @@ class DeclarativeColumnsMetaclass(type):
         if opts.model:
             extra = SortedDict()
             # honor Table.Meta.fields, fallback to model._meta.fields
-            if opts.fields:
+            if opts.fields is not None:
                 # Each item in opts.fields is the name of a model field or a
                 # normal attribute on the model
                 for field_name in opts.fields:
@@ -236,7 +236,7 @@ class TableOptions(object):
         self.attrs = AttributeDict(getattr(options, "attrs", {}))
         self.default = getattr(options, "default", "—")
         self.empty_text = getattr(options, "empty_text", None)
-        self.fields = getattr(options, "fields", ())
+        self.fields = getattr(options, "fields", None)
         self.exclude = getattr(options, "exclude", ())
         order_by = getattr(options, "order_by", None)
         if isinstance(order_by, six.string_types):
@@ -422,7 +422,10 @@ class TableBase(object):
         elif self._meta.sequence:
             self._sequence = self._meta.sequence
         else:
-            self._sequence = Sequence(self._meta.fields + ('...',))
+            if self._meta.fields is not None:
+                self._sequence = Sequence(self._meta.fields + ('...',))
+            else:
+                self._sequence = Sequence(('...',))
             self._sequence.expand(self.base_columns.keys())
         self.columns = columns.BoundColumns(self)
         # `None` value for order_by means no order is specified. This means we

--- a/tests/models.py
+++ b/tests/models.py
@@ -307,3 +307,14 @@ def unicode_field_names():
 
     table = Table(Person.objects.all())
     assert table.rows[0]["first_name"] == "Brad"
+
+
+@models.test
+def fields_empty_list_means_no_fields():
+    class Table(tables.Table):
+        class Meta:
+            model = Person
+            fields = ()
+
+    table = Table(Person.objects.all())
+    assert len(table.columns.names()) == 0


### PR DESCRIPTION
In the following situation:
```
class BaseTable(tables.Table):
    title = tables.LinkColumn('dashboard:catalogue-product', args=[tables.A('pk')])
    date_updated = tables.DateColumn(verbose_name=_("Last modified"))

    class Meta:
        fields = ('title',)
        model = Product
        sequence = ('title', 'date_updated')


class ProductTable(BaseTable):
    class Meta(BaseTable.Meta):
        pass
```

ProductTable gets the generic `Column` for `Model.title` instead of the `LinkColumn`. The reason is that `ProductTable` inherits `Meta.fields` which pulls in the generic column and overwrites `BaseTable`'s `title` column.

I'm really using `Meta.fields` here to exclude all the other columns of the `Product` model. I could use `Meta.exclude`, however that would then pull in all generic model columns, still overwriting the custom column for title – `Meta.exclude` will then just remove the other columns again.

A possible fix is to make it such that `Meta.fields = ()'` means don't use any generic model columns. You could argue to just don't set `Meta.model` in that case, however in a different class hierarchy the base table might want to use generic model columns. You'd have to unset both `Meta.fields` and `Meta.model` in the derived `Meta` class, which seems like bad API.

I'll attach a pull request to this effect after I have tested that this works in the situations I need.

I'm moving https://github.com/tangentlabs/django-oscar to django-tables2, which is why customisability is my primary goal.