### PR TITLE
Added optional request parameter to as_html.

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -445,7 +445,7 @@ class TableBase(object):
         if request:
             RequestConfig(request).configure(self)
 
-    def as_html(self):
+    def as_html(self, request=None):
         """
         Render the table to a simple HTML table.
 
@@ -454,7 +454,8 @@ class TableBase(object):
         ``{% render_table %}`` template tag instead.
         """
         template = get_template(self.template)
-        request = build_request()
+        if request is None:
+            request = build_request()
         return template.render(RequestContext(request, {'table': self}))
 
     @property


### PR DESCRIPTION
If the table happens to be rendered in Python (we are using the table to render a multiple choice widget), then the {% render_table %} template tag is difficult to use and we used as_html(). However, this clobbers the links. Being able to supply the actual request to the as_html() method solves this issue.