### PR TITLE
FIX: when orderable=False do not sort queryset

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -101,7 +101,8 @@ class TableData(object):
                 accessors += bound_column.order_by
         if hasattr(self, "queryset"):
             translate = lambda accessor: accessor.replace(Accessor.SEPARATOR, QUERYSET_ACCESSOR_SEPARATOR)
-            self.queryset = self.queryset.order_by(*(translate(a) for a in accessors))
+            if accessors:
+                self.queryset = self.queryset.order_by(*(translate(a) for a in accessors))
         else:
             self.list.sort(key=OrderByTuple(accessors).key)
 

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -38,6 +38,13 @@ class Person(models.Model):
         return "%s %s" % (self.first_name, self.last_name)
 
 
+class PersonProxy(Person):
+
+    class Meta:
+        proxy = True
+        ordering = ('last_name',)
+
+
 class Occupation(models.Model):
     name = models.CharField(max_length=200)
     region = models.ForeignKey('Region', null=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ import six
 import django_tables2 as tables
 import pytest
 
-from .app.models import Occupation, Person
+from .app.models import Occupation, Person, PersonProxy
 
 pytestmark = pytest.mark.django_db
 
@@ -205,6 +205,15 @@ def test_ordering():
 
     table = SimpleTable(Person.objects.all(), order_by="name")
     assert table.as_html()
+
+
+def test_default_order():
+    # 204
+    table = PersonTable(PersonProxy.objects.all())
+    Person.objects.create(first_name='Foo', last_name='Bar')
+    Person.objects.create(first_name='Bradley', last_name='Ayers')
+    table.data.order_by([])
+    assert list(table.rows[0])[1] == 'Ayers'
 
 
 def test_fields_should_implicitly_set_sequence():


### PR DESCRIPTION
When ``orderable`` is set to ``False`` currently queryset is sorted by nothing,
 which resets default order or order already set in queryset.

What do you think? Let me know need tests for this. 