### PR TITLE
Add MultiTableMixin to support >1 tables in one view

### DIFF
--- a/django_tables2/__init__.py
+++ b/django_tables2/__init__.py
@@ -7,7 +7,7 @@ from .columns import (BooleanColumn, Column, CheckBoxColumn, DateColumn,
 from .config  import RequestConfig
 from .utils   import A, Attrs
 try:
-    from .views   import SingleTableMixin, SingleTableView
+    from .views   import SingleTableMixin, MultiTableMixin, SingleTableView
 except ImportError:
     pass
 


### PR DESCRIPTION
This in incomplete because it doesn't support different pagination or ordering per table. It's here in case someone else wants to build a more complete solution based on that. Maybe I get around to doing it in the future :)

Use like this:
```python
class CompanyUpdateView(MultiTableMixin, UpdateView):
    class PlaceOfBusinessTable:
        table_class = PlaceOfBusinessTable
        context_table_name = "place_of_business_table"

        def get_table_data(self, view):
            return view.object.placeofbusiness_set.all()

    class SubdomainTable:
        table_class = SubdomainTable
        context_table_name = "subdomain_table"

        def get_table_data(self, view):
            return Subdomain.objects.filter(placeofbusiness__company=view.object).distinct()

    tables = [PlaceOfBusinessTable, SubdomainTable]
```