### PR TITLE
Add support to CheckBoxColumn to render a checkbox as checked

### DIFF
--- a/tests/columns.py
+++ b/tests/columns.py
@@ -113,6 +113,33 @@ def new_attrs_should_be_supported():
     assert attrs(table.rows[0]["col2"])        == {"type": "checkbox", "key": "value", "value": "data", "name": "col2"}
 
 
+@checkboxcolumn.test
+def column_is_checked():
+    with warns(DeprecationWarning):
+        class TestTable(tables.Table):
+            col = tables.CheckBoxColumn(attrs={"name": "col"}, checked='is_selected')
+
+    table = TestTable([{'col': '1', 'is_selected': True}, {'col': '2', 'is_selected': False}])
+    assert attrs(table.rows[0]["col"]) == {"type": "checkbox", "value": "1", "name": "col", "checked": "checked"}
+    assert attrs(table.rows[1]["col"]) == {"type": "checkbox", "value": "2", "name": "col"}
+
+
+@checkboxcolumn.test
+def column_is_checked_callback():
+    with warns(DeprecationWarning):
+        def is_selected(value, record):
+            if value == '1':
+                return True
+            return False
+
+        class TestTable(tables.Table):
+            col = tables.CheckBoxColumn(attrs={"name": "col"}, checked=is_selected)
+
+    table = TestTable([{'col': '1'}, {'col': '2'}])
+    assert attrs(table.rows[0]["col"]) == {"type": "checkbox", "value": "1", "name": "col", "checked": "checked"}
+    assert attrs(table.rows[1]["col"]) == {"type": "checkbox", "value": "2", "name": "col"}
+
+
 general = Tests()
 
 


### PR DESCRIPTION
### Simple version:
Using the `checked` argument, test a column in the data set is a non-falsey value

```python
class CheckTable(tables.Table):
    action = tables.CheckBoxColumn(checked='selected')
    name = tables.Column()

data = [
    {'name': 'Foo', 'selected': True},
    {'name': 'Bar', 'selected': False}
]
table = CheckTable(data)
# The first row checkbox will be checked, the second un-checked
```

### Callback support

```python
def is_selected(value, record):
    if value == 'action':
        return True
    return False

class CheckTable(tables.Table):
    action = tables.CheckBoxColumn(accessor='id', checked='status')
    username = tables.Column()

data = [
    {'id': 1, 'username': 'Foo', 'status': 'active'},
    {'id': 2, 'username': 'Bar', 'status': 'inactive'}
]
table = CheckTable(data)
# Render first row checked, with the id as the checkbox value
```
