### PR TITLE
Add 'column' field to TemplateColumn context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /example/database.sqlite
 /example/.env
 /report.pylint
+/.idea

--- a/django_tables2/columns/templatecolumn.py
+++ b/django_tables2/columns/templatecolumn.py
@@ -20,7 +20,8 @@ class TemplateColumn(Column):
     *template_code* or *template_name* and rendered with a context containing:
 
     - *record* -- data record for the current row
-    - *value* -- value from `record` that corresponds to the current column
+    - *column* -- name of the current column
+    - *value* -- value from `record` that corresponds to `column`
     - *default* -- appropriate default value to use as fallback
 
     Example:
@@ -55,6 +56,7 @@ class TemplateColumn(Column):
         # the table is being rendered via `Table.as_html`, this won't exist.
         context = getattr(table, 'context', Context())
         context.update({'default': bound_column.default,
+                        'column': bound_column.name,
                         'record': record, 'value': value})
         try:
             if self.template_code:

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -26,7 +26,7 @@
         {% block table.tbody.row %}
         <tr class="{{ forloop.counter|divisibleby:2|yesno:"even,odd" }}"> {# avoid cycle for Django 1.2-1.6 compatibility #}
             {% for column, cell in row.items %}
-                <td {{ column.attrs.td.as_html }}>{% if column.localize == None %}{{ cell }}{% else %}{% if column.localize %}{{ cell|localize }}{% else %}{{ cell|unlocalize }}{% endif %}{% endif %}</td>
+                <td data-title="{{ column.header }}" {{ column.attrs.td.as_html }}>{% if column.localize == None %}{{ cell }}{% else %}{% if column.localize %}{{ cell|localize }}{% else %}{{ cell|unlocalize }}{% endif %}{% endif %}</td>
             {% endfor %}
         </tr>
         {% endblock table.tbody.row %}

--- a/tests/columns.py
+++ b/tests/columns.py
@@ -568,6 +568,15 @@ def should_support_value():
     assert table.rows[0]["foo"] == "value=bar"
 
 
+@templatecolumn.test
+def should_support_column():
+    class Table(tables.Table):
+        tcol = tables.TemplateColumn("column={{ column }}")
+
+    table = Table([{"foo": "bar"}])
+    assert table.rows[0]["foo"] == "column=tcol"
+
+
 urlcolumn = Tests()
 
 


### PR DESCRIPTION
A small change to add a 'column' field to the context that is passed to templates rendered by TemplateColumn.  This allows for reusable column templates like this (for use making columns editable via js library):

  \<span class="editable" data-col="{{column}}" data-id="{{record.id}}">{{value}}</span>
