### PR TITLE
Add max_length attribute to person CharField

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ We're going to run through creating a tutorial app. Let's start with a simple mo
 
     # tutorial/models.py
     class Person(models.Model):
-        name = models.CharField(verbose_name="full name")
+        name = models.CharField(verbose_name="full name", max_length=200)
 
 Add some data so you have something to display in the table. Now write a view
 to pass a ``Person`` queryset into a template::


### PR DESCRIPTION
The tutorial as-is, because the max_length attribute for the CharField is required for validating the model in Django. I'm proposing with this change setting it to 200 characters, as it's done in other parts of the tutorial.