### PR TITLE
Do not fallback to get_queryset() in SingleTableMixin if self.table_data is an empty queryset

### DIFF
--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -67,7 +67,7 @@ class SingleTableMixin(object):
         """
         Return the table data that should be used to populate the rows.
         """
-        if self.table_data:
+        if self.table_data is not None:
             return self.table_data
         elif hasattr(self, "object_list"):
             return self.object_list


### PR DESCRIPTION
I wanted to use the `SingleTableMixin` class with a filtered QuerySet which I write to `self.table_data` before `get_context_data()` is called. If the QuerySet is empty, `get_table_data()` falls back to `get_queryset()` which returns the unfiltered QuerySet and the table would shows all entries.

This patch replaces the simple boolean check with `is not None`.