### PR TITLE
Clarify that you need to set table_pagination=False to disable pagination

### DIFF
--- a/docs/pages/generic-mixins.rst
+++ b/docs/pages/generic-mixins.rst
@@ -11,7 +11,9 @@ The following view parameters are supported:
 - ``table_class`` –- the table class to use, e.g. ``SimpleTable``
 - ``table_data`` (or ``get_table_data()``) -- the data used to populate the table
 - ``context_table_name`` -- the name of template variable containing the table object
-- ``table_pagination`` -- pagination options to pass to `.RequestConfig`
+- ``table_pagination`` (or ``get_table_pagination``) -- pagination
+  options to pass to `.RequestConfig`. Set ``table_pagination=False``
+  to disable pagination.
 
 .. __: https://docs.djangoproject.com/en/1.3/topics/class-based-views/
 


### PR DESCRIPTION
I answered a question on Stack Overflow where a user did not realise that they had to set table_pagination=False (instead of table_pagination=None) in order to disable pagination. Hopefully this small change to the docs will help other users in future.

http://stackoverflow.com/questions/29557279/how-do-i-control-pagination-using-a-class-based-view-in-django-tables2