### PR TITLE
Allow Meta.fields to be list as well as tuple

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -422,7 +422,7 @@ class TableBase(object):
         elif self._meta.sequence:
             self._sequence = self._meta.sequence
         else:
-            self._sequence = Sequence(self._meta.fields + ('...',))
+            self._sequence = Sequence(tuple(self._meta.fields) + ('...',))
             self._sequence.expand(self.base_columns.keys())
         self.columns = columns.BoundColumns(self)
         # `None` value for order_by means no order is specified. This means we

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -202,22 +202,30 @@ def test_ordering():
     assert table.as_html()
 
 
-def test_fields_should_implicitly_set_sequence():
+_first_last = ('last_name', 'first_name')
+
+
+@pytest.mark.parametrize('table_fields', (_first_last, list(_first_last)))
+def test_fields_should_implicitly_set_sequence(table_fields):
     class PersonTable(tables.Table):
         extra = tables.Column()
 
         class Meta:
             model = Person
-            fields = ('last_name', 'first_name')
+            fields = table_fields
     table = PersonTable(Person.objects.all())
     assert table.columns.names() == ['last_name', 'first_name', 'extra']
 
 
-def test_model_properties_should_be_useable_for_columns():
+_name_first = ('name', 'first_name')
+
+
+@pytest.mark.parametrize('table_fields', (_name_first, list(_name_first)))
+def test_model_properties_should_be_useable_for_columns(table_fields):
     class PersonTable(tables.Table):
         class Meta:
             model = Person
-            fields = ('name', 'first_name')
+            fields = table_fields
 
     Person.objects.create(first_name='Bradley', last_name='Ayers')
     table = PersonTable(Person.objects.all())


### PR DESCRIPTION
Since django's Form.Meta.Fields can be both tuple or list, I think it makes sense if tables do the same (currently it only allows tuples)