### PR TITLE
Missing page support

### DIFF
--- a/docs/pages/api-reference.rst
+++ b/docs/pages/api-reference.rst
@@ -250,6 +250,13 @@ API Reference
         :type: tuple of `unicode`
         :default: empty tuple
 
+    .. attribute:: missing_page_text
+
+        Specify a text to return, in case user tries to acces a page which does not exist (instead of raising an exception).
+        A template can also be provided, which will receive  two context variables: `table` and `page` which was attempted to access.
+
+        :type: `string` or `unicode`
+        :default: None
 
 `.BooleanColumn`
 ----------------


### PR DESCRIPTION
Ability to add a table meta option: "missing_page_text".
You can either write a text, or point a template to render.
The context sent to the template is "table" and "page" (page user asked for).

I had to re-create the fork, i as way behind upstream and got tons of conflicts. 