### PR TITLE
Test against current versions of django in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /example/database.sqlite
 /example/.env
 /report.pylint
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,32 @@
 language: python
-python:
-  - 2.7
-env:
-  - TOX_ENV=py34-dj18
-  - TOX_ENV=py34-dj17
-  - TOX_ENV=py34-dj16
-  - TOX_ENV=py34-dj15
-  - TOX_ENV=py33-dj18
-  - TOX_ENV=py33-dj17
-  - TOX_ENV=py33-dj16
-  - TOX_ENV=py33-dj15
-  - TOX_ENV=py27-dj18
-  - TOX_ENV=py27-dj17
-  - TOX_ENV=py27-dj16
-  - TOX_ENV=py27-dj15
-  - TOX_ENV=py27-dj14
-  - TOX_ENV=py27-dj13
+
+# django 1.9 is only supported on py27 and py35
+# django 1.8 is the first realease supporting py35
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-1.7
+    - python: 2.7
+      env: TOXENV=py27-1.8
+    - python: 3.2
+      env: TOXENV=py32-1.7
+    - python: 3.2
+      env: TOXENV=py32-1.8
+    - python: 3.3
+      env: TOXENV=py33-1.7
+    - python: 3.3
+      env: TOXENV=py33-1.8
+    - python: 3.4
+      env: TOXENV=py34-1.7
+    - python: 3.4
+      env: TOXENV=py34-1.8
+    - python: 3.4
+      env: TOXENV=py34-1.9
+    - python: 3.5
+      env: TOXENV=py35-1.8
+    - python: 3.5
+      env: TOXENV=py35-1.9
 install:
   - pip install tox
 script:
-  - tox -e $TOX_ENV
+  - tox

--- a/requirements/common.pip
+++ b/requirements/common.pip
@@ -1,4 +1,4 @@
-django-haystack>=2.0.0,<2.1.0
+django-haystack>=2.4.1,<2.5.0
 fudge
 lxml
 pylint

--- a/requirements/django-1.3.x.pip
+++ b/requirements/django-1.3.x.pip
@@ -1,2 +1,0 @@
--r common.pip
-Django>=1.3,<1.4

--- a/requirements/django-1.4.x.pip
+++ b/requirements/django-1.4.x.pip
@@ -1,2 +1,0 @@
--r common.pip
-Django>=1.4,<1.5

--- a/requirements/django-1.5.x.pip
+++ b/requirements/django-1.5.x.pip
@@ -1,2 +1,0 @@
--r common.pip
-Django>=1.5,<1.6

--- a/requirements/django-1.6.x.pip
+++ b/requirements/django-1.6.x.pip
@@ -1,2 +1,0 @@
--r common.pip
-Django>=1.6,<1.7

--- a/requirements/django-1.7.x.pip
+++ b/requirements/django-1.7.x.pip
@@ -1,2 +1,0 @@
--r common.pip
-Django>=1.7,<1.8

--- a/requirements/django-1.8.x.pip
+++ b/requirements/django-1.8.x.pip
@@ -1,2 +1,0 @@
--r common.pip
-Django>=1.8,<1.9

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -1,6 +1,7 @@
-from django.conf import global_settings
-import six
+import os
 
+import six
+from django.conf import global_settings
 
 DATABASES = {
     'default': {
@@ -11,6 +12,8 @@ DATABASES = {
 
 INSTALLED_APPS = [
     'tests.app',
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
     'django_tables2',
 ]
 

--- a/tests/columns/test_booleancolumn.py
+++ b/tests/columns/test_booleancolumn.py
@@ -1,14 +1,19 @@
 # coding: utf-8
 # pylint: disable=R0912,E0102
 from __future__ import unicode_literals
-import django_tables2 as tables
+
 from django.db import models
+
+import django_tables2 as tables
+
 from ..utils import attrs
 
 
 def test_should_be_used_for_booleanfield():
     class BoolModel(models.Model):
         field = models.BooleanField()
+        class Meta:
+            app_label = 'django_tables2_test'
 
     class Table(tables.Table):
         class Meta:
@@ -22,6 +27,8 @@ def test_should_be_used_for_booleanfield():
 def test_should_be_used_for_nullbooleanfield():
     class NullBoolModel(models.Model):
         field = models.NullBooleanField()
+        class Meta:
+            app_label = 'django_tables2_test'
 
     class Table(tables.Table):
         class Meta:

--- a/tests/columns/test_datecolumn.py
+++ b/tests/columns/test_datecolumn.py
@@ -1,11 +1,13 @@
 # coding: utf-8
 # pylint: disable=R0912,E0102
 from __future__ import unicode_literals
+
 from datetime import date
 
 from django.db import models
 
 import django_tables2 as tables
+
 
 # Format string: https://docs.djangoproject.com/en/1.4/ref/templates/builtins/#date
 # D -- Day of the week, textual, 3 letters  -- 'Fri'
@@ -58,7 +60,8 @@ def test_should_handle_short_format(settings):
 def test_should_be_used_for_datefields():
     class DateModel(models.Model):
         field = models.DateField()
-
+        class Meta:
+            app_label = 'django_tables2_test'
     class Table(tables.Table):
         class Meta:
             model = DateModel

--- a/tests/columns/test_datetimecolumn.py
+++ b/tests/columns/test_datetimecolumn.py
@@ -1,18 +1,19 @@
 # coding: utf-8
 # pylint: disable=R0912,E0102
 from __future__ import unicode_literals
+
 from datetime import datetime
 
+import pytz
 from django.db import models
 
 import django_tables2 as tables
+import pytest
 
 try:
     from django.utils import timezone
 except ImportError:
     timezone = None
-import pytz
-import pytest
 
 # Format string: https://docs.djangoproject.com/en/1.4/ref/templates/builtins/#date
 # D -- Day of the week, textual, 3 letters  -- 'Fri'
@@ -73,6 +74,8 @@ def test_should_handle_short_format(dt, settings):
 def test_should_be_used_for_datetimefields():
     class DateTimeModel(models.Model):
         field = models.DateTimeField()
+        class Meta:
+            app_label = 'django_tables2_test'
 
     class Table(tables.Table):
         class Meta:

--- a/tests/columns/test_emailcolumn.py
+++ b/tests/columns/test_emailcolumn.py
@@ -31,6 +31,8 @@ def test_should_render_default_for_blank():
 def test_should_be_used_for_datetimefields():
     class EmailModel(models.Model):
         field = models.EmailField()
+        class Meta:
+            app_label = 'django_tables2_test'
 
     class Table(tables.Table):
         class Meta:

--- a/tests/columns/test_filecolumn.py
+++ b/tests/columns/test_filecolumn.py
@@ -4,13 +4,14 @@ from __future__ import unicode_literals
 
 from os.path import dirname, join
 
-from django.db import models
-from django.db.models.fields.files import FieldFile
 from django.core.files.base import ContentFile
 from django.core.files.storage import FileSystemStorage
-import pytest
+from django.db import models
+from django.db.models.fields.files import FieldFile
 
 import django_tables2 as tables
+import pytest
+
 from ..utils import parse
 
 
@@ -30,6 +31,8 @@ def column():
 def test_should_be_used_for_filefields():
     class FileModel(models.Model):
         field = models.FileField()
+        class Meta:
+            app_label = 'django_tables2_test'
 
     class Table(tables.Table):
         class Meta:

--- a/tests/columns/test_urlcolumn.py
+++ b/tests/columns/test_urlcolumn.py
@@ -18,6 +18,8 @@ def test_should_turn_url_into_hyperlink():
 def test_should_be_used_for_urlfields():
     class URLModel(models.Model):
         field = models.URLField()
+        class Meta:
+            app_label = 'django_tables2_test'
 
     class Table(tables.Table):
         class Meta:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 import six
+
+import django_tables2 as tables
 import pytest
 
-from .app.models import Person, Occupation
-import django_tables2 as tables
-
+from .app.models import Occupation, Person
 
 pytestmark = pytest.mark.django_db
 
@@ -52,6 +52,8 @@ def test_model_table():
         char = models.CharField(max_length=200)
         fk = models.ForeignKey("self")
         m2m = models.ManyToManyField("self")
+        class Meta:
+            app_label = 'django_tables2_test'
 
     class ComplexTable(tables.Table):
         class Meta:
@@ -158,6 +160,9 @@ def test_field_choices_used_to_translated_value():
     class Article(models.Model):
         name = models.CharField(max_length=200)
         language = models.CharField(max_length=200, choices=LANGUAGES)
+
+        class Meta:
+            app_label = 'django_tables2_test'
 
         def __unicode__(self):
             return self.name

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,29 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=tests.app.settings
 
+[tox]
+args_are_paths = false
+envlist =
+    {py27,py32,py33,py34}-{1.7,1.8},
+    {py27,py34,py35}-{1.9, master}
+
 [testenv]
+basepython =
+    py27: python2.7
+    py32: python3.2
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
+usedevelop = true
+pip_pre = true
 setenv = PYTHONPATH={toxinidir}
 commands = py.test
+deps =
+    1.7: Django>=1.7,<1.8
+    1.8: Django>=1.8,<1.9
+    1.9: Django>=1.9,<1.10
+    master: https://github.com/django/django/archive/master.tar.gz
+    -r{toxinidir}/requirements/common.pip
 
 [testenv:docs]
 changedir = docs
@@ -11,80 +31,3 @@ commands = make html
 deps =
     -r{toxinidir}/requirements/django-dev.pip
     Sphinx
-
-; -- python 3.4 ---------------------------------------------------------------
-
-[testenv:py34-dj]
-basepython = python3.4
-commands = python -W error {envbindir}/coverage run setup.py test []
-deps = -r{toxinidir}/requirements/django-dev.pip
-
-[testenv:py34-dj18]
-basepython = python3.4
-deps = -r{toxinidir}/requirements/django-1.8.x.pip
-
-[testenv:py34-dj17]
-basepython = python3.4
-deps = -r{toxinidir}/requirements/django-1.7.x.pip
-
-[testenv:py34-dj16]
-basepython = python3.4
-deps = -r{toxinidir}/requirements/django-1.6.x.pip
-
-[testenv:py34-dj15]
-basepython = python3.4
-deps = -r{toxinidir}/requirements/django-1.5.x.pip
-
-; -- python 3.3 ---------------------------------------------------------------
-
-[testenv:py33-dj]
-basepython = python3.3
-commands = python -W error {envbindir}/coverage run setup.py test []
-deps = -r{toxinidir}/requirements/django-dev.pip
-
-[testenv:py33-dj18]
-basepython = python3.3
-deps = -r{toxinidir}/requirements/django-1.8.x.pip
-
-[testenv:py33-dj17]
-basepython = python3.3
-deps = -r{toxinidir}/requirements/django-1.7.x.pip
-
-[testenv:py33-dj16]
-basepython = python3.3
-deps = -r{toxinidir}/requirements/django-1.6.x.pip
-
-[testenv:py33-dj15]
-basepython = python3.3
-deps = -r{toxinidir}/requirements/django-1.5.x.pip
-
-; -- python 2.7 ---------------------------------------------------------------
-
-[testenv:py27-dj]
-basepython = python2.7
-commands = python -W error {envbindir}/coverage run setup.py test []
-deps = -r{toxinidir}/requirements/django-dev.pip
-
-[testenv:py27-dj18]
-basepython = python2.7
-deps = -r{toxinidir}/requirements/django-1.8.x.pip
-
-[testenv:py27-dj17]
-basepython = python2.7
-deps = -r{toxinidir}/requirements/django-1.7.x.pip
-
-[testenv:py27-dj16]
-basepython = python2.7
-deps = -r{toxinidir}/requirements/django-1.6.x.pip
-
-[testenv:py27-dj15]
-basepython = python2.7
-deps = -r{toxinidir}/requirements/django-1.5.x.pip
-
-[testenv:py27-dj14]
-basepython = python2.7
-deps = -r{toxinidir}/requirements/django-1.4.x.pip
-
-[testenv:py27-dj13]
-basepython = python2.7
-deps = -r{toxinidir}/requirements/django-1.3.x.pip


### PR DESCRIPTION
 - Ignore .cache
 - Make test pass in django 1.9 by adding a bunch of app_labels
 - Remove requirements files, deps managed in tox.ini