### PR TITLE
Pass a dict to template.render() to remove RemovedInDjango110Warning.

### DIFF
--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -1,20 +1,23 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
+
+import re
+import tokenize
+from collections import OrderedDict
+
+import six
 from django import template
 from django.core.exceptions import ImproperlyConfigured
-from django.template import TemplateSyntaxError, Variable, Node
+from django.template import Node, TemplateSyntaxError, Variable
+from django.template.defaultfilters import title as old_title
+from django.template.defaultfilters import stringfilter
 from django.template.loader import get_template, select_template
-from django.template.defaultfilters import stringfilter, title as old_title
-from django.utils.http import urlencode
 from django.utils.html import escape
+from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
+
 import django_tables2 as tables
 from django_tables2.config import RequestConfig
-from collections import OrderedDict
-import re
-import six
-import tokenize
-
 
 register = template.Library()
 kwarg_re = re.compile(r"(?:(.+)=)?(.+)")
@@ -203,7 +206,7 @@ class RenderTableNode(Node):
             # achieved is to temporarily attach the context to the table,
             # which TemplateColumn then looks for and uses.
             table.context = context
-            return template.render(context)
+            return template.render(context.flatten())
         finally:
             del table.context
             context.pop()


### PR DESCRIPTION
django_tables2/templatetags/django_tables2.py:206:
RemovedInDjango110Warning: render() must be called with a dict, not a RequestContext.

Hmm, this has the same problem as dyve/django-bootstrap3/pull/292, it doesn't work for django 1.7. Any idea how to reliably fix this @dyve. 