### PR TITLE
Get build working with django-master (becoming django 1.10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ matrix:
       env: TOXENV=py27-1.7
     - python: 2.7
       env: TOXENV=py27-1.8
-    - python: 3.2
-      env: TOXENV=py32-1.7
-    - python: 3.2
-      env: TOXENV=py32-1.8
     - python: 3.3
       env: TOXENV=py33-1.7
     - python: 3.3
@@ -26,6 +22,14 @@ matrix:
       env: TOXENV=py35-1.8
     - python: 3.5
       env: TOXENV=py35-1.9
+    - python: 2.7
+      env: TOXENV=py27-master
+    - python: 3.5
+      env: TOXENV=py35-master
+
+  allow_failures:
+      - env: TOXENV=py27-master
+      - env: TOXENV=py35-master
 install:
   - pip install tox
 script:

--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ globally, use:
 
 1. Bump the version in `django-tables2/__init__.py`.
 2. Update `CHANGELOG.md`.
-3. Run `python setup.py sdist upload --sign --identity=<your gpg identity>`.
+3. Create a tag `git tag -a v1.0.6 -m 'tagging v1.0.6'`
+4. Run `python setup.py sdist upload --sign --identity=<your gpg identity>`.

--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -1,8 +1,9 @@
 # coding: utf-8
-from .utils import A, getargspec
+import six
 from django.db import models
 from django.db.models.fields import FieldDoesNotExist
-import six
+
+from .utils import A, getargspec
 
 
 class BoundRow(object):
@@ -26,7 +27,7 @@ class BoundRow(object):
         >>> table = SimpleTable([{'a': 1, 'b': 2}])
         >>> row = table.rows[0]  # we only have one row, so let's use it
         >>> for cell in row:
-        ...     print cell
+        ...     print(cell)
         ...
         1
         <input type="checkbox" name="my_chkbox" value="2" />

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -6,16 +6,20 @@ import warnings
 from collections import OrderedDict
 
 import six
-from django.core.paginator import Paginator
-from django.db.models.fields import FieldDoesNotExist
-from django.template import RequestContext
-from django.template.loader import get_template
+from django import VERSION
+from django.core.paginator       import Paginator
+from django.db.models.fields     import FieldDoesNotExist
+from django.template             import RequestContext
+from django.template.loader      import get_template
+from collections import OrderedDict
+import six
+import warnings
 
 from . import columns
 from .config import RequestConfig
 from .rows import BoundRows
 from .utils import (Accessor, AttributeDict, OrderBy, OrderByTuple, Sequence,
-                    build_request, cached_property, computed_values, segment)
+                    cached_property, computed_values, segment)
 
 QUERYSET_ACCESSOR_SEPARATOR = '__'
 
@@ -458,7 +462,7 @@ class TableBase(object):
         if request:
             RequestConfig(request).configure(self)
 
-    def as_html(self):
+    def as_html(self, request=None):
         """
         Render the table to a simple HTML table.
 
@@ -467,8 +471,16 @@ class TableBase(object):
         ``{% render_table %}`` template tag instead.
         """
         template = get_template(self.template)
-        request = build_request()
-        return template.render(RequestContext(request, {'table': self}))
+
+        context = {'table': self}
+
+        if request:
+            if VERSION < (1, 8):
+                context = RequestContext(request, context)
+            else:
+                context['request'] = request
+
+        return template.render(context)
 
     @property
     def attrs(self):

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -6,8 +6,6 @@ import warnings
 from itertools import chain
 
 import six
-from django.core.handlers.wsgi import WSGIRequest
-from django.test.client import FakePayload
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
@@ -488,34 +486,6 @@ funcs = (name for name in ('getfullargspec', 'getargspec')
                        if hasattr(inspect, name))
 getargspec = getattr(inspect, next(funcs))
 del funcs
-
-
-def build_request(uri='/'):
-    """
-    Return a fresh HTTP GET / request.
-
-    This is essentially a heavily cutdown version of Django 1.3's
-    `~django.test.client.RequestFactory`.
-    """
-    path, _, querystring = uri.partition('?')
-    return WSGIRequest({
-        'CONTENT_TYPE':      'text/html; charset=utf-8',
-        'PATH_INFO':         path,
-        'QUERY_STRING':      querystring,
-        'REMOTE_ADDR':       '127.0.0.1',
-        'REQUEST_METHOD':    'GET',
-        'SCRIPT_NAME':       '',
-        'SERVER_NAME':       'testserver',
-        'SERVER_PORT':       '80',
-        'SERVER_PROTOCOL':   'HTTP/1.1',
-        'wsgi.version':      (1, 0),
-        'wsgi.url_scheme':   'http',
-        'wsgi.input':        FakePayload(b''),
-        'wsgi.errors':       six.StringIO(),
-        'wsgi.multiprocess': True,
-        'wsgi.multithread':  False,
-        'wsgi.run_once':     False,
-    })
 
 
 def total_ordering(cls):

--- a/example/settings.py
+++ b/example/settings.py
@@ -116,7 +116,7 @@ else:
             'APP_DIRS': True,
             'OPTIONS': {
                 'context_processors': [
-                    'django.core.context_processors.request',
+                    'django.templates.context_processors.request',
                     'django.contrib.auth.context_processors.auth',
                 ],
             }

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -30,11 +30,10 @@ else:
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': ['templates'],
             'APP_DIRS': True,
             'OPTIONS': {
                 'context_processors': [
-                    'django.core.context_processors.request'
+                    'django.template.context_processors.request'
                 ],
             }
         }

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -1,13 +1,12 @@
 # coding: utf-8
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 from . import views
 
-
-urlpatterns = patterns('',
-    url(r'^people/(?P<pk>\d+)/$',      views.person,     name='person'),
+urlpatterns = [
+    url(r'^people/(?P<pk>\d+)/$', views.person, name='person'),
     url(r'^occupations/(?P<pk>\d+)/$', views.occupation, name='occupation'),
-    url(r'^&\'"/(?P<pk>\d+)/$',        lambda req: None, name='escaping'),
-)
+    url(r'^&\'"/(?P<pk>\d+)/$', lambda req: None, name='escaping'),
+]

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -2,14 +2,16 @@
 # pylint: disable=R0912,E0102
 from __future__ import unicode_literals
 
-import django_tables2 as tables
+import pytest
 from django.utils.safestring import SafeData, mark_safe
 from django.utils.translation import ugettext_lazy
 
-import pytest
+import django_tables2 as tables
 
 from ..app.models import Person
-from ..utils import parse, warns
+from ..utils import build_request, parse, warns
+
+request = build_request('/')
 
 
 def test_column_render_supports_kwargs():
@@ -274,7 +276,7 @@ def test_should_support_both_meta_sequence_and_constructor_exclude():
             sequence = ('a', '...')
 
     table = SequencedTable([], exclude=('c', ))
-    table.as_html()
+    table.as_html(request)
 
 
 def test_bound_columns_should_support_indexing():
@@ -293,7 +295,7 @@ def test_cell_attrs_applies_to_td_and_th():
 
     # providing data ensures 1 row is rendered
     table = SimpleTable([{"a": "value"}])
-    root = parse(table.as_html())
+    root = parse(table.as_html(request))
 
     assert root.findall('.//thead/tr/th')[0].attrib == {"key": "value", "class": "a orderable sortable"}
     assert root.findall('.//tbody/tr/td')[0].attrib == {"key": "value", "class": "a"}
@@ -304,7 +306,7 @@ def test_cells_are_automatically_given_column_name_as_class():
         a = tables.Column()
 
     table = SimpleTable([{"a": "value"}])
-    root = parse(table.as_html())
+    root = parse(table.as_html(request))
     assert root.findall('.//thead/tr/th')[0].attrib == {"class": "a orderable sortable"}
     assert root.findall('.//tbody/tr/td')[0].attrib == {"class": "a"}
 
@@ -315,7 +317,7 @@ def test_th_are_given_sortable_class_if_column_is_orderable():
         b = tables.Column(orderable=False)
 
     table = SimpleTable([{"a": "value"}])
-    root = parse(table.as_html())
+    root = parse(table.as_html(request))
     # return classes of an element as a set
     classes = lambda x: set(x.attrib["class"].split())
     assert "sortable" in classes(root.findall('.//thead/tr/th')[0])
@@ -323,7 +325,7 @@ def test_th_are_given_sortable_class_if_column_is_orderable():
 
     # Now try with an ordered table
     table = SimpleTable([], order_by="a")
-    root = parse(table.as_html())
+    root = parse(table.as_html(request))
     # return classes of an element as a set
     assert "sortable" in classes(root.findall('.//thead/tr/th')[0])
     assert "asc" in classes(root.findall('.//thead/tr/th')[0])

--- a/tests/columns/test_linkcolumn.py
+++ b/tests/columns/test_linkcolumn.py
@@ -7,12 +7,11 @@ from django.core.urlresolvers import reverse
 from django.template import Context, Template
 from django.utils.html import mark_safe
 from django_tables2 import A
-from django_tables2.utils import build_request
 
 import pytest
 
 from ..app.models import Person
-from ..utils import attrs, warns
+from ..utils import attrs, build_request, warns
 
 
 def test_unicode():
@@ -81,15 +80,17 @@ def test_null_foreign_key():
 
     Person.objects.create(first_name='bradley', last_name='ayers')
 
+    request = build_request()
     table = PersonTable(Person.objects.all())
-    table.as_html()
+    table.as_html(request)
 
 
 def test_kwargs():
     class PersonTable(tables.Table):
         a = tables.LinkColumn('occupation', kwargs={"pk": A('a')})
 
-    html = PersonTable([{"a": 0}, {"a": 1}]).as_html()
+    request = build_request('/')
+    html = PersonTable([{"a": 0}, {"a": 1}]).as_html(request)
     assert reverse("occupation", kwargs={"pk": 0}) in html
     assert reverse("occupation", kwargs={"pk": 1}) in html
 
@@ -154,4 +155,4 @@ def test_get_absolute_url_not_defined():
     ])
 
     with pytest.raises(TypeError):
-        table.as_html()
+        table.as_html(build_request('/'))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,11 @@
 # coding: utf-8
-from django_tables2 import RequestConfig
-from django_tables2.utils import build_request
+import pytest
 from django.core.paginator import EmptyPage, PageNotAnInteger
 from fudge import Fake
-import pytest
 
+from django_tables2 import RequestConfig
+
+from .utils import build_request
 
 NOTSET = object()  # unique value
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,14 +1,20 @@
 # coding: utf-8
 """Test the core table functionality."""
 from __future__ import absolute_import, unicode_literals
+
 import copy
+import itertools
+
+import pytest
+import six
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+
 import django_tables2 as tables
 from django_tables2.tables import DeclarativeColumnsMetaclass
-import six
-import itertools
-import pytest
-from .utils import warns
+
+from .utils import build_request, warns
+
+request = build_request('/')
 
 
 class UnorderedTable(tables.Table):
@@ -168,17 +174,17 @@ def test_should_support_haystack_data_source():
         first_name = tables.Column()
 
     table = PersonTable(SearchQuerySet().all())
-    table.as_html()
+    table.as_html(request)
 
 
 def test_data_validation():
     with pytest.raises(ValueError):
         table = OrderedTable(None)
-    
+
     class Bad:
         def __len__(self):
             pass
-      
+
     with pytest.raises(ValueError):
         table = OrderedTable(Bad())
 
@@ -189,7 +195,7 @@ def test_data_validation():
             if pos != 0:
                 raise IndexError()
             return {'a': 1}
-    
+
     table = OrderedTable(Ok())
     assert len(table.rows) == 1
 
@@ -442,7 +448,7 @@ def test_pagination_shouldnt_prevent_multiple_rendering():
     table = SimpleTable([{'name': 'brad'}])
     table.paginate()
 
-    assert table.as_html() == table.as_html()
+    assert table.as_html(request) == table.as_html(request)
 
 
 def test_empty_text():
@@ -560,7 +566,7 @@ def test_template_in_meta_class_declaration_should_be_honored():
 
     table = MetaDeclarationSpecifiedTemplateTable([])
     assert table.template == "dummy.html"
-    assert table.as_html() == "dummy template contents\n"
+    assert table.as_html(request) == "dummy template contents\n"
 
 
 def test_should_support_rendering_multiple_times():
@@ -569,7 +575,7 @@ def test_should_support_rendering_multiple_times():
 
     # test list data
     table = MultiRenderTable([{'name': 'brad'}])
-    assert table.as_html() == table.as_html()
+    assert table.as_html(request) == table.as_html(request)
 
 
 def test_column_defaults_are_honored():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,13 +1,14 @@
 # coding: utf-8
+import pytest
 import six
 
 import django_tables2 as tables
-import pytest
 
 from .app.models import Occupation, Person, PersonProxy
+from .utils import build_request
 
 pytestmark = pytest.mark.django_db
-
+request = build_request('/')
 
 class PersonTable(tables.Table):
     first_name = tables.Column()
@@ -187,7 +188,7 @@ def test_column_mapped_to_nonexistant_field():
         missing = tables.Column()
 
     table = FaultyPersonTable(Person.objects.all())
-    table.as_html()  # the bug would cause this to raise FieldDoesNotExist
+    table.as_html(request)  # the bug would cause this to raise FieldDoesNotExist
 
 
 def test_should_support_rendering_multiple_times():
@@ -196,7 +197,7 @@ def test_should_support_rendering_multiple_times():
 
     # test queryset data
     table = MultiRenderTable(Person.objects.all())
-    assert table.as_html() == table.as_html()
+    assert table.as_html(request) == table.as_html(request)
 
 
 def test_ordering():
@@ -204,7 +205,7 @@ def test_ordering():
         name = tables.Column(order_by=("first_name", "last_name"))
 
     table = SimpleTable(Person.objects.all(), order_by="name")
-    assert table.as_html()
+    assert table.as_html(request)
 
 
 def test_default_order():
@@ -244,7 +245,7 @@ def test_column_with_delete_accessor_shouldnt_delete_records():
 
     Person.objects.create(first_name='Bradley', last_name='Ayers')
     table = PersonTable(Person.objects.all())
-    table.as_html()
+    table.as_html(request)
     assert Person.objects.get(first_name='Bradley')
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,27 +1,29 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from django.test import TransactionTestCase
 import django
+import lxml.etree
+import lxml.html
+import pytest
+import six
 from django.core.exceptions import ImproperlyConfigured
-from django.template import Template, RequestContext, Context
-from django.utils.translation import ugettext_lazy
+from django.template import Context, RequestContext, Template
+from django.test import TransactionTestCase
 from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext_lazy
 
-from .app.models import Person, Region
 import django_tables2 as tables
 from django_tables2.config import RequestConfig
-from django_tables2.utils import build_request
+
+from .app.models import Person, Region
+from .utils import build_request, parse, translation
 
 try:
     from urlparse import parse_qs
 except ImportError:
     from urllib.parse import parse_qs
-import lxml.etree
-import lxml.html
-import six
-from .utils import parse, translation
-import pytest
+
+request = build_request('/')
 
 
 class CountryTable(tables.Table):
@@ -48,7 +50,7 @@ MEMORY_DATA = [
 
 def test_as_html():
     table = CountryTable(MEMORY_DATA)
-    root = parse(table.as_html())
+    root = parse(table.as_html(request))
     assert len(root.findall('.//thead/tr')) == 1
     assert len(root.findall('.//thead/tr/th')) == 4
     assert len(root.findall('.//tbody/tr')) == 4
@@ -56,14 +58,14 @@ def test_as_html():
 
     # no data with no empty_text
     table = CountryTable([])
-    root = parse(table.as_html())
+    root = parse(table.as_html(request))
     assert 1 == len(root.findall('.//thead/tr'))
     assert 4 == len(root.findall('.//thead/tr/th'))
     assert 0 == len(root.findall('.//tbody/tr'))
 
     # no data WITH empty_text
     table = CountryTable([], empty_text='this table is empty')
-    root = parse(table.as_html())
+    root = parse(table.as_html(request))
     assert 1 == len(root.findall('.//thead/tr'))
     assert 4 == len(root.findall('.//thead/tr/th'))
     assert 1 == len(root.findall('.//tbody/tr'))
@@ -73,14 +75,14 @@ def test_as_html():
 
     # data without header
     table = CountryTable(MEMORY_DATA, show_header=False)
-    root = parse(table.as_html())
+    root = parse(table.as_html(request))
     assert len(root.findall('.//thead')) == 0
     assert len(root.findall('.//tbody/tr')) == 4
     assert len(root.findall('.//tbody/tr/td')) == 16
 
     # with custom template
     table = CountryTable([], template="django_tables2/table.html")
-    table.as_html()
+    table.as_html(request)
 
 
 def test_custom_rendering():
@@ -104,8 +106,8 @@ def test_custom_rendering():
 
 
 def test_render_table_templatetag(settings):
-    # ensure it works with a multi-order-by
     request = build_request('/')
+    # ensure it works with a multi-order-by
     table = CountryTable(MEMORY_DATA, order_by=('name', 'population'))
     RequestConfig(request).configure(table)
     template = Template('{% load django_tables2 %}{% render_table table %}')
@@ -251,7 +253,7 @@ def test_whitespace_is_preserved():
     class TestTable(tables.Table):
         name = tables.Column(verbose_name=mark_safe("<b>foo</b> <i>bar</i>"))
 
-    html = TestTable([{"name": mark_safe("<b>foo</b> <i>bar</i>")}]).as_html()
+    html = TestTable([{"name": mark_safe("<b>foo</b> <i>bar</i>")}]).as_html(request)
 
     tree = parse(html)
 
@@ -265,8 +267,10 @@ def test_as_html_db_queries(transactional_db):
         class Meta:
             model = Person
 
+    # TODO: check why this is commented out
     # with queries(count=1):
-    #     PersonTable(Person.objects.all()).as_html()
+    #     PersonTable(Person.objects.all()).as_html(request)
+
 
 @pytest.mark.django_db
 class TestQueries(TransactionTestCase):
@@ -276,7 +280,7 @@ class TestQueries(TransactionTestCase):
                 model = Person
 
         with self.assertNumQueries(1):
-            PersonTable(Person.objects.all()).as_html()
+            PersonTable(Person.objects.all()).as_html(request)
 
     def test_render_table_db_queries(self):
         Person.objects.create(first_name="brad", last_name="ayers")
@@ -316,11 +320,11 @@ def test_localization_check(settings):
     }
 
     # no localization
-    html = get_cond_localized_table(None)(simple_test_data).as_html()
+    html = get_cond_localized_table(None)(simple_test_data).as_html(request)
     assert '<td class="name">{0}</td>'.format(expected_reults[None]) in html
 
     # unlocalize
-    html = get_cond_localized_table(False)(simple_test_data).as_html()
+    html = get_cond_localized_table(False)(simple_test_data).as_html(request)
     assert '<td class="name">{0}</td>'.format(expected_reults[False]) in html
 
     settings.USE_L10N = True
@@ -329,16 +333,16 @@ def test_localization_check(settings):
     with translation("pl"):
         # with default polish locales and enabled thousand separator
         # 1234.5 is formatted as "1 234,5" with nbsp
-        html = get_cond_localized_table(True)(simple_test_data).as_html()
+        html = get_cond_localized_table(True)(simple_test_data).as_html(request)
         assert '<td class="name">{0}</td>'.format(expected_reults[True]) in html
 
         # with localize = False there should be no formatting
-        html = get_cond_localized_table(False)(simple_test_data).as_html()
+        html = get_cond_localized_table(False)(simple_test_data).as_html(request)
         assert '<td class="name">{0}</td>'.format(expected_reults[False]) in html
 
         # with localize = None and USE_L10N = True
         # there should be the same formatting as with localize = True
-        html = get_cond_localized_table(None)(simple_test_data).as_html()
+        html = get_cond_localized_table(None)(simple_test_data).as_html(request)
         assert '<td class="name">{0}</td>'.format(expected_reults[True]) in html
 
 
@@ -380,7 +384,7 @@ def test_localization_check_in_meta(settings):
     }
 
     # No localize
-    html = TableNoLocalize(simple_test_data).as_html()
+    html = TableNoLocalize(simple_test_data).as_html(request)
     assert '<td class="name">{0}</td>'.format(expected_reults[None]) in html
 
     settings.USE_L10N = True
@@ -389,17 +393,17 @@ def test_localization_check_in_meta(settings):
     with translation("pl"):
         # the same as in localization_check.
         # with localization and polish locale we get formatted output
-        html = TableNoLocalize(simple_test_data).as_html()
+        html = TableNoLocalize(simple_test_data).as_html(request)
         assert '<td class="name">{0}</td>'.format(expected_reults[True]) in html
 
         # localize
-        html = TableLocalize(simple_test_data).as_html()
+        html = TableLocalize(simple_test_data).as_html(request)
         assert '<td class="name">{0}</td>'.format(expected_reults[True]) in html
 
         # unlocalize
-        html = TableUnlocalize(simple_test_data).as_html()
+        html = TableUnlocalize(simple_test_data).as_html(request)
         assert '<td class="name">{0}</td>'.format(expected_reults[False]) in html
 
         # test unlocalize higher precedence
-        html = TableLocalizePrecedence(simple_test_data).as_html()
+        html = TableLocalizePrecedence(simple_test_data).as_html(request)
         assert '<td class="name">{0}</td>'.format(expected_reults[False]) in html

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 # from attest import assert_hook, raises, Tests
 import six
-import pytest
+from django_tables2.utils import (Accessor, AttributeDict, OrderBy,
+                                  OrderByTuple, computed_values, segment)
 
-from django_tables2.utils import (Accessor, AttributeDict, computed_values,
-                                  OrderByTuple, OrderBy, segment)
+import pytest
 
 
 def test_orderbytuple():
@@ -128,7 +128,7 @@ def test_compute_values_supports_shallow_structures():
     assert x == {"foo": "bar"}
 
 
-def test_compute_values_supports_shallow_structures():
+def test_compute_values_supports_nested_structures():
     x = computed_values({"foo": lambda: {"bar": lambda: "baz"}})
     assert x == {"foo": {"bar": "baz"}}
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,9 +1,10 @@
 # coding: utf-8
-from .app.models import Region
 import django_tables2 as tables
-from django_tables2.utils import build_request
+
 import pytest
 
+from .app.models import Region
+from .utils import build_request
 
 USING_CBV = hasattr(tables, "SingleTableView")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,12 @@
+import warnings
 from contextlib import contextmanager
+
 import lxml.etree
 import lxml.html
-import warnings
+import six
+from django.core.handlers.wsgi import WSGIRequest
+from django.template import RequestContext
+from django.test.client import FakePayload
 
 
 def parse(html):
@@ -48,3 +53,31 @@ def translation(language_code, deactivate=False):
             translation.deactivate()
         else:
             translation.activate(original)
+
+
+def build_request(uri='/'):
+    """
+    Return a fresh HTTP GET / request.
+
+    This is essentially a heavily cutdown version of Django 1.3's
+    `~django.test.client.RequestFactory`.
+    """
+    path, _, querystring = uri.partition('?')
+    return WSGIRequest({
+        'CONTENT_TYPE':      'text/html; charset=utf-8',
+        'PATH_INFO':         path,
+        'QUERY_STRING':      querystring,
+        'REMOTE_ADDR':       '127.0.0.1',
+        'REQUEST_METHOD':    'GET',
+        'SCRIPT_NAME':       '',
+        'SERVER_NAME':       'testserver',
+        'SERVER_PORT':       '80',
+        'SERVER_PROTOCOL':   'HTTP/1.1',
+        'wsgi.version':      (1, 0),
+        'wsgi.url_scheme':   'http',
+        'wsgi.input':        FakePayload(b''),
+        'wsgi.errors':       six.StringIO(),
+        'wsgi.multiprocess': True,
+        'wsgi.multithread':  False,
+        'wsgi.run_once':     False,
+    })

--- a/tox.ini
+++ b/tox.ini
@@ -4,26 +4,29 @@ DJANGO_SETTINGS_MODULE=tests.app.settings
 [tox]
 args_are_paths = false
 envlist =
-    {py27,py32,py33,py34}-{1.7,1.8},
-    {py27,py34,py35}-{1.9, master}
+    {py27,py33,py34}-{1.7,1.8},
+    {py27,py34,py35}-{1.9,master}
 
 [testenv]
 basepython =
     py27: python2.7
-    py32: python3.2
     py33: python3.3
     py34: python3.4
     py35: python3.5
 usedevelop = true
 pip_pre = true
 setenv = PYTHONPATH={toxinidir}
-commands = py.test
+commands =
+    py.test --cov=django_tables2
+    coverage html
 deps =
     1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     master: https://github.com/django/django/archive/master.tar.gz
     -r{toxinidir}/requirements/common.pip
+    pytest-cov
+    coverage
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
- Add `request` argument to Table.as_html() to allow passing correct request objects instead of poorly generated ones.
- Add coverage reporting to build
- Drop support for python 3.2 (because of coverage), support ends feb 2016
- move `build_request` from `django_table2.utils` to `tests.utils` and amend tests.

## Todo:
- [ ] Document API change of `Table.as_html()`