### PR TITLE
Improve supplied template(s)

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
 
-import warnings
 from collections import OrderedDict
 from itertools import islice
 

--- a/django_tables2/columns/checkboxcolumn.py
+++ b/django_tables2/columns/checkboxcolumn.py
@@ -1,8 +1,6 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
 
-import warnings
-
 from django.utils.safestring import mark_safe
 
 from django_tables2.utils import AttributeDict

--- a/django_tables2/static/django_tables2/bootstrap.css
+++ b/django_tables2/static/django_tables2/bootstrap.css
@@ -1,0 +1,8 @@
+.table-container th.asc:after {
+    content: '\0000a0\0025b2';
+    float: right;
+}
+.table-container th.desc:after {
+    content: '\0000a0\0025bc';
+    float: right;
+}

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import copy
-import warnings
 from collections import OrderedDict
 
 import six

--- a/django_tables2/templates/django_tables2/bootstrap.html
+++ b/django_tables2/templates/django_tables2/bootstrap.html
@@ -1,0 +1,74 @@
+{% load querystring from django_tables2 %}
+{% load i18n %}
+{% load blocktrans trans from i18n %}
+
+<div class="table-container">
+    {% block table %}
+        <table class="table table-bordered table-striped"{% if table.attrs %} {{ table.attrs.as_html }}{% endif %}>
+            {% block table.thead %}
+                <thead>
+                <tr>
+                    {% for column in table.columns %}
+                        {% if column.orderable %}
+                            <th {{ column.attrs.th.as_html }}>
+                                <a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a>
+                            </th>
+                        {% else %}
+                            <th {{ column.attrs.th.as_html }}>{{ column.header }}</th>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+                </thead>
+            {% endblock table.thead %}
+            {% block table.tbody %}
+                <tbody>
+                {% for row in table.page.object_list|default:table.rows %} {# support pagination #}
+                    {% block table.tbody.row %}
+                        <tr class="{% cycle "odd" "even" %}">
+                            {% for column, cell in row.items %}
+                                <td {{ column.attrs.td.as_html }}>{{ cell }}</td>
+                            {% endfor %}
+                        </tr>
+                    {% endblock table.tbody.row %}
+                {% empty %}
+                    {% block table.tbody.empty_text %}
+                        {% trans "no results" as table_empty_text %}
+                        <tr>
+                            <td colspan="{{ table.columns|length }}">{{ table.empty_text|default:table_empty_text }}</td>
+                        </tr>
+                    {% endblock table.tbody.empty_text %}
+                {% endfor %}
+                </tbody>
+            {% endblock table.tbody %}
+            {% block table.tfoot %}
+                <tfoot></tfoot>
+            {% endblock table.tfoot %}
+        </table>
+    {% endblock table %}
+
+    {% if table.page and table.paginator.num_pages > 1 %}
+        {% block pagination %}
+        <ul class="pager">
+            {% if table.page.has_previous %}
+            <li class="previous">
+                <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}" class="btn btn-default">
+                    {% trans 'previous' %}
+                </a>
+            {% endif %}
+            <li class="cardinality">
+                {% blocktrans with table.page.number as current and table.paginator.num_pages as total %}
+                    Page {{ current }} of {{ total }}
+                {% endblocktrans %}
+            </li>
+            {% if table.page.has_next %}
+            <li class="next">
+                <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}" class="btn btn-default">
+                    {% trans 'next' %}
+                </a>
+            </li>
+            {% endif %}
+        </ul>
+
+        {% endblock pagination %}
+    {% endif %}
+</div>

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -1,9 +1,8 @@
 {% spaceless %}
 {% load django_tables2 %}
 {% load i18n %}
-{% if table.page %}
+
 <div class="table-container">
-{% endif %}
 {% block table %}
 <table{% if table.attrs %} {{ table.attrs.as_html }}{% endif %}>
     {% nospaceless %}
@@ -70,6 +69,6 @@
 {% endblock pagination %}
 {% endwith %}
 {% endwith %}
-</div>
 {% endif %}
+</div>
 {% endspaceless %}

--- a/django_tables2/templates/django_tables2/table.html
+++ b/django_tables2/templates/django_tables2/table.html
@@ -1,11 +1,9 @@
-{% spaceless %}
 {% load django_tables2 %}
 {% load i18n %}
 
 <div class="table-container">
 {% block table %}
 <table{% if table.attrs %} {{ table.attrs.as_html }}{% endif %}>
-    {% nospaceless %}
     {% block table.thead %}
     {% if table.show_header %}
     <thead>
@@ -43,7 +41,7 @@
     {% block table.tfoot %}
     <tfoot></tfoot>
     {% endblock table.tfoot %}
-    {% endnospaceless %}
+
 </table>
 {% endblock table %}
 
@@ -53,22 +51,38 @@
 {% block pagination %}
 <ul class="pagination">
     {% if table.page.has_previous %}
-    {% nospaceless %}{% block pagination.previous %}<li class="previous"><a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">{% trans "Previous" %}</a></li>{% endblock pagination.previous %}{% endnospaceless %}
+        {% block pagination.previous %}
+            <li class="previous">
+                <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">{% trans "Previous" %}</a>
+            </li>
+        {% endblock pagination.previous %}
     {% endif %}
 
     {% if table.page.has_previous or table.page.has_next %}
-    {% nospaceless %}{% block pagination.current %}<li class="current">{% blocktrans with table.page.number as current and table.paginator.num_pages as total %}Page {{ current }} of {{ total }}{% endblocktrans %}</li>{% endblock pagination.current %}{% endnospaceless %}
+        {% block pagination.current %}
+            <li class="current">
+                {% blocktrans with table.page.number as current and table.paginator.num_pages as total %}
+                    Page {{ current }} of {{ total }}
+                {% endblocktrans %}
+            </li>
+        {% endblock pagination.current %}
     {% endif %}
 
     {% if table.page.has_next %}
-    {% nospaceless %}{% block pagination.next %}<li class="next"><a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">{% trans "Next" %}</a></li>{% endblock pagination.next %}{% endnospaceless %}
+        {% block pagination.next %}
+            <li class="next">
+                <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">{% trans "Next" %}</a>
+            </li>
+        {% endblock pagination.next %}
     {% endif %}
-
-    {% nospaceless %}{% block pagination.cardinality %}<li class="cardinality">{% if total != count %}{% blocktrans %}{{ count }} of {{ total }}{% endblocktrans %}{% else %}{{ total }}{% endif %} {% if total == 1 %}{{ table.data.verbose_name }}{% else %}{{ table.data.verbose_name_plural }}{% endif %}</li>{% endblock pagination.cardinality %}{% endnospaceless %}
+    {% block pagination.cardinality %}
+        <li class="cardinality">
+            {% if total != count %}{% blocktrans %}{{ count }} of {{ total }}{% endblocktrans %}{% else %}{{ total }}{% endif %} {% if total == 1 %}{{ table.data.verbose_name }}{% else %}{{ table.data.verbose_name_plural }}{% endif %}
+        </li>
+    {% endblock pagination.cardinality %}
 </ul>
 {% endblock pagination %}
 {% endwith %}
 {% endwith %}
 {% endif %}
 </div>
-{% endspaceless %}

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 import re
 from collections import OrderedDict
 
+import django_tables2 as tables
 import six
 from django import template
 from django.core.exceptions import ImproperlyConfigured
@@ -15,8 +16,6 @@ from django.templatetags.l10n import register as l10n_register
 from django.utils.html import escape
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
-
-import django_tables2 as tables
 from django_tables2.config import RequestConfig
 
 register = template.Library()
@@ -197,22 +196,6 @@ def render_table(parser, token):
 
     template = parser.compile_filter(bits.pop(0)) if bits else None
     return RenderTableNode(table, template)
-
-
-class NoSpacelessNode(Node):
-    def __init__(self, nodelist):
-        self.nodelist = nodelist
-        super(NoSpacelessNode, self).__init__()
-
-    def render(self, context):
-        return mark_safe(re.sub(r'>\s+<', '>&#32;<', self.nodelist.render(context)))
-
-
-@register.tag
-def nospaceless(parser, token):
-    nodelist = parser.parse(('endnospaceless',))
-    parser.delete_first_token()
-    return NoSpacelessNode(nodelist)
 
 
 RE_UPPERCASE = re.compile('[A-Z]')

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -2,13 +2,12 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
-import tokenize
 from collections import OrderedDict
 
 import six
 from django import template
 from django.core.exceptions import ImproperlyConfigured
-from django.template import Node, TemplateSyntaxError, Variable
+from django.template import Node, TemplateSyntaxError
 from django.template.defaultfilters import title as old_title
 from django.template.defaultfilters import stringfilter
 from django.template.loader import get_template, select_template

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import inspect
-import warnings
 from functools import total_ordering
 from itertools import chain
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,15 +1,13 @@
 # coding: utf-8
 import os
-from os.path import abspath, dirname, join
 import re
 import sys
+from os.path import abspath
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "example.settings"
 
 # import project
 sys.path.insert(0, abspath('..'))
-import example
-import django_tables2
 sys.path.pop(0)
 
 

--- a/example/app/tables.py
+++ b/example/app/tables.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import django_tables2 as tables
-from .models import Country
+
+from .models import Country, Person
 
 
 class CountryTable(tables.Table):
@@ -17,3 +18,9 @@ class CountryTable(tables.Table):
 class ThemedCountryTable(CountryTable):
     class Meta:
         attrs = {'class': 'paleblue'}
+
+
+class BootstrapTable(tables.Table):
+    class Meta:
+        model = Person
+        template = 'django_tables2/bootstrap.html'

--- a/example/app/views.py
+++ b/example/app/views.py
@@ -4,7 +4,13 @@ from django.shortcuts import render
 from django_tables2 import RequestConfig, SingleTableView
 
 from .models import Country, Person
-from .tables import CountryTable, ThemedCountryTable
+from .tables import BootstrapTable, CountryTable, ThemedCountryTable
+
+try:
+    from django.utils.lorem_ipsum import words
+except ImportError:
+    # django 1.7 has lorem_ipsum in contrib.webdisign, moved in 1.8
+    from django.contrib.webdesign.lorem_ipsum import words
 
 
 def multiple(request):
@@ -32,6 +38,20 @@ def multiple(request):
         'example3': example3,
         'example4': example4,
         'example5': example5,
+    })
+
+
+def bootstrap(request):
+    '''Demonstrate the use of the bootstrap template'''
+    # create some fake data to make sure we need to paginate
+    if Person.objects.all().count() < 50:
+        Person.objects.create_bulk([Person(name=words(3, common=False)) for i in range(50)])
+
+    table = BootstrapTable(Person.objects.all())
+    RequestConfig(request, paginate={"per_page": 10}).configure(table)
+
+    return render(request, 'bootstrap_template.html', {
+        'table': table
     })
 
 

--- a/example/settings.py
+++ b/example/settings.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-# import django_tables2
-import sys
 from os.path import abspath, dirname, join
 
 from django import VERSION
@@ -97,6 +95,7 @@ if VERSION < (1, 8):
     )
 
     TEMPLATE_CONTEXT_PROCESSORS = [
+        'django.contrib.auth.context_processors.auth',
         'django.core.context_processors.static',
         'django.core.context_processors.request'
     ]

--- a/example/templates/bootstrap_template.html
+++ b/example/templates/bootstrap_template.html
@@ -1,0 +1,22 @@
+{% load render_table from django_tables2 %}
+<!doctype html>
+<html>
+<head>
+    <title>django_tables2 with bootstrap template example</title>
+
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="{{ STATIC_URL }}django_tables2/bootstrap.css" rel="stylesheet" />
+</head>
+<body>
+    <div class="container">
+
+        <h3>django_tables2 with bootstrap template example</h3>
+
+        <div class="row">
+            <div class="col-sm-10">
+                {% render_table table %}
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/example/urls.py
+++ b/example/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.views import static
 
-from app.views import class_based, multiple, tutorial
+from app.views import bootstrap, class_based, multiple, tutorial
 
 admin.autodiscover()
 
@@ -12,6 +12,7 @@ urlpatterns = [
     url(r'^$', multiple),
     url(r'^class-based/$', class_based),
     url(r'^tutorial/$', tutorial),
+    url(r'^bootstrap/$', bootstrap),
 
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/', include(admin.site.urls)),

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -10,12 +10,11 @@ from django.utils.translation import ugettext, ugettext_lazy
 
 try:
     # Django >= 1.7
-    from django.contrib.contenttypes.fields import (GenericForeignKey,
-                                                    GenericRelation)
+    from django.contrib.contenttypes.fields import GenericForeignKey
+
 except ImportError:
     # Django < 1.7, TODO: remove if we drop support for 1.7
-    from django.contrib.contenttypes.generic import (GenericForeignKey,
-                                                     GenericRelation)
+    from django.contrib.contenttypes.generic import GenericForeignKey
 
 
 class Person(models.Model):

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -1,5 +1,3 @@
-import os
-
 import six
 from django import VERSION
 from django.conf import global_settings

--- a/tests/columns/test_checkboxcolumn.py
+++ b/tests/columns/test_checkboxcolumn.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import django_tables2 as tables
 
-from ..utils import attrs, warns
+from ..utils import attrs
 
 
 def test_new_attrs_should_be_supported():

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_lazy
 import django_tables2 as tables
 
 from ..app.models import Person
-from ..utils import build_request, parse, warns
+from ..utils import build_request, parse
 
 request = build_request('/')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,7 +12,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 import django_tables2 as tables
 from django_tables2.tables import DeclarativeColumnsMetaclass
 
-from .utils import build_request, warns
+from .utils import build_request
 
 request = build_request('/')
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,29 +1,16 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-import django
-import lxml.etree
-import lxml.html
 import pytest
-import six
-from django.core.exceptions import ImproperlyConfigured
-from django.template import Context, RequestContext, Template
+from django.template import Context, Template
 from django.test import TransactionTestCase
-from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy
 
 import django_tables2 as tables
 from django_tables2.config import RequestConfig
 
-from .app.models import Person, Region
+from .app.models import Person
 from .utils import build_request, parse, translation
-
-try:
-    from urlparse import parse_qs
-except ImportError:
-    from urllib.parse import parse_qs
-
-request = build_request('/')
 
 
 class CountryTable(tables.Table):
@@ -49,6 +36,7 @@ MEMORY_DATA = [
 
 
 def test_as_html():
+    request = build_request('/')
     table = CountryTable(MEMORY_DATA)
     root = parse(table.as_html(request))
     assert len(root.findall('.//thead/tr')) == 1
@@ -70,7 +58,7 @@ def test_as_html():
     assert 4 == len(root.findall('.//thead/tr/th'))
     assert 1 == len(root.findall('.//tbody/tr'))
     assert 1 == len(root.findall('.//tbody/tr/td'))
-    assert int(root.find('.//tbody/tr/td').attrib['colspan']) == len(root.findall('.//thead/tr/th'))
+    assert int(root.find('.//tbody/tr/td').get('colspan')) == len(root.findall('.//thead/tr/th'))
     assert root.find('.//tbody/tr/td').text == 'this table is empty'
 
     # data without header
@@ -105,180 +93,14 @@ def test_custom_rendering():
     assert result == template.render(context)
 
 
-def test_render_table_templatetag(settings):
-    request = build_request('/')
-    # ensure it works with a multi-order-by
-    table = CountryTable(MEMORY_DATA, order_by=('name', 'population'))
-    RequestConfig(request).configure(table)
-    template = Template('{% load django_tables2 %}{% render_table table %}')
-    html = template.render(Context({'request': request, 'table': table}))
-
-    root = parse(html)
-    assert len(root.findall('.//thead/tr')) == 1
-    assert len(root.findall('.//thead/tr/th')) == 4
-    assert len(root.findall('.//tbody/tr')) == 4
-    assert len(root.findall('.//tbody/tr/td')) == 16
-    assert root.find('ul[@class="pagination"]/li[@class="cardinality"]').text == '4 items'
-
-    # no data with no empty_text
-    table = CountryTable([])
-    template = Template('{% load django_tables2 %}{% render_table table %}')
-    html = template.render(Context({'request': build_request('/'), 'table': table}))
-    root = parse(html)
-    assert len(root.findall('.//thead/tr')) == 1
-    assert len(root.findall('.//thead/tr/th')) == 4
-    assert len(root.findall('.//tbody/tr')) == 0
-
-    # no data WITH empty_text
-    request = build_request('/')
-    table = CountryTable([], empty_text='this table is empty')
-    RequestConfig(request).configure(table)
-    template = Template('{% load django_tables2 %}{% render_table table %}')
-    html = template.render(Context({'request': request, 'table': table}))
-    root = parse(html)
-    assert len(root.findall('.//thead/tr')) == 1
-    assert len(root.findall('.//thead/tr/th')) == 4
-    assert len(root.findall('.//tbody/tr')) == 1
-    assert len(root.findall('.//tbody/tr/td')) == 1
-    assert int(root.find('.//tbody/tr/td').attrib['colspan']) == len(root.findall('.//thead/tr/th'))
-    assert root.find('.//tbody/tr/td').text == 'this table is empty'
-
-    # variable that doesn't exist (issue #8)
-    template = Template('{% load django_tables2 %}'
-                        '{% render_table this_doesnt_exist %}')
-    with pytest.raises(ValueError):
-        settings.DEBUG = True
-        template.render(Context())
-
-    # Should still be noisy with debug off
-    with pytest.raises(ValueError):
-        settings.DEBUG = False
-        template.render(Context())
-
-
-def test_render_table_should_support_template_argument():
-    table = CountryTable(MEMORY_DATA, order_by=('name', 'population'))
-    template = Template('{% load django_tables2 %}'
-                        '{% render_table table "dummy.html" %}')
-    request = build_request('/')
-    context = RequestContext(request, {'table': table})
-    assert template.render(context) == 'dummy template contents\n'
-
-
-@pytest.mark.django_db
-def test_render_table_supports_queryset():
-    for name in ("Mackay", "Brisbane", "Maryborough"):
-        Region.objects.create(name=name)
-    template = Template('{% load django_tables2 %}{% render_table qs %}')
-    html = template.render(Context({'qs': Region.objects.all(),
-                                    'request': build_request('/')}))
-
-    root = parse(html)
-    assert [e.text for e in root.findall('.//thead/tr/th/a')] == ["ID", "name", "mayor"]
-    td = [[td.text for td in tr.findall('td')] for tr in root.findall('.//tbody/tr')]
-    db = []
-    for region in Region.objects.all():
-        db.append([six.text_type(region.id), region.name, "—"])
-    assert td == db
-
-
-def test_querystring_templatetag():
-    template = Template('{% load django_tables2 %}'
-                        '<b>{% querystring "name"="Brad" foo.bar=value %}</b>')
-
-    # Should be something like: <root>?name=Brad&amp;a=b&amp;c=5&amp;age=21</root>
-    xml = template.render(Context({
-        "request": build_request('/?a=b&name=dog&c=5'),
-        "foo": {"bar": "age"},
-        "value": 21,
-    }))
-
-    # Ensure it's valid XML, retrieve the URL
-    url = parse(xml).text
-
-    qs = parse_qs(url[1:])  # everything after the ? pylint: disable=C0103
-    assert qs["name"] == ["Brad"]
-    assert qs["age"] == ["21"]
-    assert qs["a"] == ["b"]
-    assert qs["c"] == ["5"]
-
-
-def test_querystring_templatetag_requires_request():
-    with pytest.raises(ImproperlyConfigured):
-        (Template('{% load django_tables2 %}{% querystring "name"="Brad" %}')
-         .render(Context()))
-
-
-def test_querystring_templatetag_supports_without():
-    context = Context({
-        "request": build_request('/?a=b&name=dog&c=5'),
-        "a_var": "a",
-    })
-
-    template = Template('{% load django_tables2 %}'
-                        '<b>{% querystring "name"="Brad" without a_var %}</b>')
-    url = parse(template.render(context)).text
-    qs = parse_qs(url[1:])  # trim the ? pylint: disable=C0103
-    assert set(qs.keys()) == set(["name", "c"])
-
-    # Try with only exclusions
-    template = Template('{% load django_tables2 %}'
-                        '<b>{% querystring without "a" "name" %}</b>')
-    url = parse(template.render(context)).text
-    qs = parse_qs(url[1:])  # trim the ? pylint: disable=C0103
-    assert set(qs.keys()) == set(["c"])
-
-
-def test_title_should_only_apply_to_words_without_uppercase_letters():
-    expectations = {
-        "a brown fox": "A Brown Fox",
-        "a brown foX": "A Brown foX",
-        "black FBI": "Black FBI",
-        "f.b.i": "F.B.I",
-        "start 6pm": "Start 6pm",
-    }
-
-    for raw, expected in expectations.items():
-        template = Template("{% load django_tables2 %}{{ x|title }}")
-        assert template.render(Context({"x": raw})) == expected
-
-
-def test_nospaceless_works():
-    template = Template("{% load django_tables2 %}"
-                        "{% spaceless %}<b>a</b> <i>b {% nospaceless %}<b>c</b>"
-                        "  <b>d</b> {% endnospaceless %}lic</i>{% endspaceless %}")
-    assert template.render(Context()) == "<b>a</b><i>b <b>c</b>&#32;<b>d</b> lic</i>"
-
-
-def test_whitespace_is_preserved():
-    class TestTable(tables.Table):
-        name = tables.Column(verbose_name=mark_safe("<b>foo</b> <i>bar</i>"))
-
-    html = TestTable([{"name": mark_safe("<b>foo</b> <i>bar</i>")}]).as_html(request)
-
-    tree = parse(html)
-
-    assert "<b>foo</b> <i>bar</i>" in lxml.etree.tostring(tree.findall('.//thead/tr/th')[0], encoding='unicode')
-    assert "<b>foo</b> <i>bar</i>" in lxml.etree.tostring(tree.findall('.//tbody/tr/td')[0], encoding='unicode')
-
-
-@pytest.mark.django_db
-def test_as_html_db_queries(transactional_db):
-    class PersonTable(tables.Table):
-        class Meta:
-            model = Person
-
-    # TODO: check why this is commented out
-    # with queries(count=1):
-    #     PersonTable(Person.objects.all()).as_html(request)
-
-
 @pytest.mark.django_db
 class TestQueries(TransactionTestCase):
     def test_as_html_db_queries(self):
         class PersonTable(tables.Table):
             class Meta:
                 model = Person
+
+        request = build_request('/')
 
         with self.assertNumQueries(1):
             PersonTable(Person.objects.all()).as_html(request)
@@ -291,6 +113,7 @@ class TestQueries(TransactionTestCase):
             class Meta:
                 model = Person
                 per_page = 1
+        request = build_request('/')
 
         with self.assertNumQueries(2):
             # one query for pagination: .count()
@@ -318,6 +141,7 @@ def test_localization_check(settings):
         False: '1234.5',
         True: '1 234,5'  # non-breaking space
     }
+    request = build_request('/')
 
     # no localization
     html = get_cond_localized_table(None)(simple_test_data).as_html(request)
@@ -381,7 +205,7 @@ def test_localization_check_in_meta(settings):
         False: '1234.5',
         True: '1{0}234,5'.format(' ')  # non-breaking space
     }
-
+    request = build_request('/')
     # No localize
     html = TableNoLocalize(simple_test_data).as_html(request)
     assert '<td class="name">{0}</td>'.format(expected_results[None]) in html
@@ -406,3 +230,27 @@ def test_localization_check_in_meta(settings):
         # test unlocalize higher precedence
         html = TableLocalizePrecedence(simple_test_data).as_html(request)
         assert '<td class="name">{0}</td>'.format(expected_results[False]) in html
+
+
+class BootstrapTable(CountryTable):
+    class Meta:
+        template = 'django_tables2/bootstrap.html'
+        prefix = 'bootstrap-'
+
+
+def test_boostrap_template():
+    table = BootstrapTable(MEMORY_DATA)
+    request = build_request('/')
+    RequestConfig(request, {'per_page': 2}).configure(table)
+
+    template = Template('{% load django_tables2 %}{% render_table table %}')
+    html = template.render(Context({'request': request, 'table': table}))
+    root = parse(html)
+    assert len(root.findall('.//thead/tr')) == 1
+    assert len(root.findall('.//thead/tr/th')) == 4
+    assert len(root.findall('.//tbody/tr')) == 2
+    assert len(root.findall('.//tbody/tr/td')) == 8
+
+    assert root.find('ul[@class="pager"]/li[@class="cardinality"]').text.strip() == 'Page 1 of 2'
+    # make sure the link is prefixed
+    assert root.find('ul[@class="pager"]/li[@class="next"]/a').get('href') == '?bootstrap-page=2'

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,0 +1,187 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import lxml.etree
+import lxml.html
+import pytest
+import six
+from django.core.exceptions import ImproperlyConfigured
+from django.template import Context, RequestContext, Template
+from django.utils.safestring import mark_safe
+
+import django_tables2 as tables
+from django_tables2.config import RequestConfig
+from six.moves.urllib.parse import parse_qs
+
+from .app.models import Person, Region
+from .test_templates import MEMORY_DATA, CountryTable
+from .utils import build_request, parse
+
+
+def test_render_table_templatetag(settings):
+    request = build_request('/')
+    # ensure it works with a multi-order-by
+    table = CountryTable(MEMORY_DATA, order_by=('name', 'population'))
+    RequestConfig(request).configure(table)
+    template = Template('{% load django_tables2 %}{% render_table table %}')
+    html = template.render(Context({'request': request, 'table': table}))
+
+    root = parse(html)
+    assert len(root.findall('.//thead/tr')) == 1
+    assert len(root.findall('.//thead/tr/th')) == 4
+    assert len(root.findall('.//tbody/tr')) == 4
+    assert len(root.findall('.//tbody/tr/td')) == 16
+    assert root.find('ul[@class="pagination"]/li[@class="cardinality"]').text == '4 items'
+
+    # no data with no empty_text
+    table = CountryTable([])
+    template = Template('{% load django_tables2 %}{% render_table table %}')
+    html = template.render(Context({'request': build_request('/'), 'table': table}))
+    root = parse(html)
+    assert len(root.findall('.//thead/tr')) == 1
+    assert len(root.findall('.//thead/tr/th')) == 4
+    assert len(root.findall('.//tbody/tr')) == 0
+
+    # no data WITH empty_text
+    request = build_request('/')
+    table = CountryTable([], empty_text='this table is empty')
+    RequestConfig(request).configure(table)
+    template = Template('{% load django_tables2 %}{% render_table table %}')
+    html = template.render(Context({'request': request, 'table': table}))
+    root = parse(html)
+    assert len(root.findall('.//thead/tr')) == 1
+    assert len(root.findall('.//thead/tr/th')) == 4
+    assert len(root.findall('.//tbody/tr')) == 1
+    assert len(root.findall('.//tbody/tr/td')) == 1
+    assert int(root.find('.//tbody/tr/td').get('colspan')) == len(root.findall('.//thead/tr/th'))
+    assert root.find('.//tbody/tr/td').text == 'this table is empty'
+
+    # variable that doesn't exist (issue #8)
+    template = Template('{% load django_tables2 %}'
+                        '{% render_table this_doesnt_exist %}')
+    with pytest.raises(ValueError):
+        settings.DEBUG = True
+        template.render(Context())
+
+    # Should still be noisy with debug off
+    with pytest.raises(ValueError):
+        settings.DEBUG = False
+        template.render(Context())
+
+
+def test_render_table_should_support_template_argument():
+    table = CountryTable(MEMORY_DATA, order_by=('name', 'population'))
+    template = Template('{% load django_tables2 %}'
+                        '{% render_table table "dummy.html" %}')
+    request = build_request('/')
+    context = RequestContext(request, {'table': table})
+    assert template.render(context) == 'dummy template contents\n'
+
+
+@pytest.mark.django_db
+def test_render_table_supports_queryset():
+    for name in ("Mackay", "Brisbane", "Maryborough"):
+        Region.objects.create(name=name)
+    template = Template('{% load django_tables2 %}{% render_table qs %}')
+    html = template.render(Context({'qs': Region.objects.all(),
+                                    'request': build_request('/')}))
+
+    root = parse(html)
+    assert [e.text for e in root.findall('.//thead/tr/th/a')] == ["ID", "name", "mayor"]
+    td = [[td.text for td in tr.findall('td')] for tr in root.findall('.//tbody/tr')]
+    db = []
+    for region in Region.objects.all():
+        db.append([six.text_type(region.id), region.name, "—"])
+    assert td == db
+
+
+def test_querystring_templatetag():
+    template = Template('{% load django_tables2 %}'
+                        '<b>{% querystring "name"="Brad" foo.bar=value %}</b>')
+
+    # Should be something like: <root>?name=Brad&amp;a=b&amp;c=5&amp;age=21</root>
+    xml = template.render(Context({
+        "request": build_request('/?a=b&name=dog&c=5'),
+        "foo": {"bar": "age"},
+        "value": 21,
+    }))
+
+    # Ensure it's valid XML, retrieve the URL
+    url = parse(xml).text
+
+    qs = parse_qs(url[1:])  # everything after the ?
+    assert qs["name"] == ["Brad"]
+    assert qs["age"] == ["21"]
+    assert qs["a"] == ["b"]
+    assert qs["c"] == ["5"]
+
+
+def test_querystring_templatetag_requires_request():
+    with pytest.raises(ImproperlyConfigured):
+        (Template('{% load django_tables2 %}{% querystring "name"="Brad" %}')
+         .render(Context()))
+
+
+def test_querystring_templatetag_supports_without():
+    context = Context({
+        "request": build_request('/?a=b&name=dog&c=5'),
+        "a_var": "a",
+    })
+
+    template = Template('{% load django_tables2 %}'
+                        '<b>{% querystring "name"="Brad" without a_var %}</b>')
+    url = parse(template.render(context)).text
+    qs = parse_qs(url[1:])  # trim the ?
+    assert set(qs.keys()) == set(["name", "c"])
+
+    # Try with only exclusions
+    template = Template('{% load django_tables2 %}'
+                        '<b>{% querystring without "a" "name" %}</b>')
+    url = parse(template.render(context)).text
+    qs = parse_qs(url[1:])  # trim the ?
+    assert set(qs.keys()) == set(["c"])
+
+
+def test_title_should_only_apply_to_words_without_uppercase_letters():
+    expectations = {
+        "a brown fox": "A Brown Fox",
+        "a brown foX": "A Brown foX",
+        "black FBI": "Black FBI",
+        "f.b.i": "F.B.I",
+        "start 6pm": "Start 6pm",
+    }
+
+    for raw, expected in expectations.items():
+        template = Template("{% load django_tables2 %}{{ x|title }}")
+        assert template.render(Context({"x": raw})) == expected
+
+
+def test_nospaceless_works():
+    template = Template("{% load django_tables2 %}"
+                        "{% spaceless %}<b>a</b> <i>b {% nospaceless %}<b>c</b>"
+                        "  <b>d</b> {% endnospaceless %}lic</i>{% endspaceless %}")
+    assert template.render(Context()) == "<b>a</b><i>b <b>c</b>&#32;<b>d</b> lic</i>"
+
+
+def test_whitespace_is_preserved():
+    class TestTable(tables.Table):
+        name = tables.Column(verbose_name=mark_safe("<b>foo</b> <i>bar</i>"))
+
+    request = build_request('/')
+    html = TestTable([{"name": mark_safe("<b>foo</b> <i>bar</i>")}]).as_html(request)
+
+    tree = parse(html)
+
+    assert "<b>foo</b> <i>bar</i>" in lxml.etree.tostring(tree.findall('.//thead/tr/th')[0], encoding='unicode')
+    assert "<b>foo</b> <i>bar</i>" in lxml.etree.tostring(tree.findall('.//tbody/tr/td')[0], encoding='unicode')
+
+
+@pytest.mark.django_db
+def test_as_html_db_queries(transactional_db):
+    class PersonTable(tables.Table):
+        class Meta:
+            model = Person
+
+    # TODO: check why this is commented out
+    # with queries(count=1):
+    #     PersonTable(Person.objects.all()).as_html(request)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,6 @@ import lxml.etree
 import lxml.html
 import six
 from django.core.handlers.wsgi import WSGIRequest
-from django.template import RequestContext
 from django.test.client import FakePayload
 
 


### PR DESCRIPTION
I just did an initial import of @dyve's [bootstrap template](https://github.com/bradleyayers/django-tables2/issues/285#issuecomment-168597935). It depends on [django-bootstrap3](https://github.com/dyve/django-bootstrap3) for the pagination. 

Todo:
- [x] hardcode the pagination functionality from `bootstrap_paginate` in the template.
- [x] Add test foor bootstrap template.
- [x] Add [css for bootstrap template](https://github.com/bradleyayers/django-tables2/issues/141#issuecomment-17057444)
- [x] Remove inconsistency from `django_tables2/table.html` (issue #149)
- [x] Make sure `prefix` is prepended to the pagination links

