### PR TITLE
Make Meta.fields = () mean take no columns from the model fields.

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -180,7 +180,7 @@ class DeclarativeColumnsMetaclass(type):
         if opts.model:
             extra = OrderedDict()
             # honor Table.Meta.fields, fallback to model._meta.fields
-            if opts.fields:
+            if opts.fields is not None:
                 # Each item in opts.fields is the name of a model field or a
                 # normal attribute on the model
                 for field_name in opts.fields:
@@ -239,7 +239,7 @@ class TableOptions(object):
         self.attrs = AttributeDict(getattr(options, "attrs", {}))
         self.default = getattr(options, "default", "—")
         self.empty_text = getattr(options, "empty_text", None)
-        self.fields = getattr(options, "fields", ())
+        self.fields = getattr(options, "fields", None)
         self.exclude = getattr(options, "exclude", ())
         order_by = getattr(options, "order_by", None)
         if isinstance(order_by, six.string_types):
@@ -348,7 +348,6 @@ class TableBase(object):
         :type: `bool`
 
 
-
     .. attribute:: prefix
 
         A prefix for querystring fields to avoid name-clashes when using
@@ -428,7 +427,10 @@ class TableBase(object):
         elif self._meta.sequence:
             self._sequence = self._meta.sequence
         else:
-            self._sequence = Sequence(tuple(self._meta.fields) + ('...', ))
+            if self._meta.fields is not None:
+                self._sequence = Sequence(tuple(self._meta.fields) + ('...', ))
+            else:
+                self._sequence = Sequence(('...', ))
             self._sequence.expand(self.base_columns.keys())
         self.columns = columns.BoundColumns(self)
         # `None` value for order_by means no order is specified. This means we

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,8 @@
 # coding: utf-8
-import pytest
 import six
 
 import django_tables2 as tables
+import pytest
 
 from .app.models import Occupation, Person, PersonProxy
 from .utils import build_request
@@ -325,4 +325,14 @@ def test_foreign_key():
     class PersonTable(tables.Table):
         class Meta:
             model = Person
-            fields = ('foreign_key',)
+            fields = ('foreign_key', )
+
+
+def fields_empty_list_means_no_fields():
+    class Table(tables.Table):
+        class Meta:
+            model = Person
+            fields = ()
+
+    table = Table(Person.objects.all())
+    assert len(table.columns.names()) == 0


### PR DESCRIPTION
refs #183

Previously any non-truthy value meant take all columns from the model
fields. This prevented changing a column autogenerated from a model field
in a base class from being overridden in a derived class with a custom
column. If the column was left in Meta.fields the autogenerated column
would overwrite the custom column, so you had to remove it from
Meta.fields. However if that was the last column in Meta.fields it would
then be empty, including all model columns.

by @mbertheau