### PR TITLE
BooleanColumn: Test case that breaks with choice=... parameter

### DIFF
--- a/tests/columns/test_booleancolumn.py
+++ b/tests/columns/test_booleancolumn.py
@@ -86,3 +86,30 @@ def test_boolean_field_choices():
 
     assert table.rows[0]['field'] == '<span class="true">✔</span>'
     assert table.rows[1]['field'] == '<span class="false">✘</span>'
+
+
+def test_boolean_field_choices_with_real_model_instances():
+    BOOL_CHOICES=((True, "Yes"),
+                  (False, "No"))
+    
+    class BoolModel(models.Model):
+        field = models.BooleanField(
+            choices=BOOL_CHOICES
+        )
+
+    class Meta:
+        app_label = 'django_tables2_test'
+
+    class Table(tables.Table):
+        class Meta:
+            model = BoolModel
+
+    tb_true=BoolModel(field=True)
+    tb_false=BoolModel(field=False)
+    
+    table = Table(data=[tb_true, tb_false])
+
+    assert table.rows[0]['field'] == '<span class="true">✔</span>'
+    assert table.rows[1]['field'] == '<span class="false">✘</span>'
+
+    


### PR DESCRIPTION
Adds test_boolean_field_choices_with_real_model_instances() to
tests/columns/test_booleancolumn.py.

After a wild-goose chase suspecting Django localization (which was
apparently not the problem), this is a test case that will fail for a
BooleanColumn representing a model.BooleanField with a
choices=... parameter set.

The reason that this test fails seems to be somewhere in the code path
that handles real model data. The test will pass when just using a pair of
mock-up dictionaries.

The test will also pass when removing the choices=... parameter from the
field = models.BooleanField(...) declaration.