### PR TITLE
Fix BooleanColumn with choices set will always render as if True

### DIFF
--- a/django_tables2/columns/booleancolumn.py
+++ b/django_tables2/columns/booleancolumn.py
@@ -41,8 +41,7 @@ class BooleanColumn(Column):
         # a boolean.
         if hasattr(record, '_meta'):
             try:
-                accessor = self.accessor or Accessor(bound_column.name)
-                field = accessor.get_field(record)
+                field = bound_column.accessor.get_field(record)
 
                 if hasattr(field, 'choices') and field.choices is not None:
                     value = next(val for val, name in field.choices if name == value)

--- a/django_tables2/columns/booleancolumn.py
+++ b/django_tables2/columns/booleancolumn.py
@@ -35,7 +35,14 @@ class BooleanColumn(Column):
             kwargs["empty_values"] = ()
         super(BooleanColumn, self).__init__(**kwargs)
 
-    def render(self, value):
+    def render(self, value, record, bound_column):
+        # if the model field has choices defined, we need to inverse lookup the
+        # value to convert to boolean correctly
+        if hasattr(record, '_meta'):
+            field = record._meta.get_field(bound_column.name)
+            if hasattr(field, 'choices'):
+                value = next(val for val, name in field.choices if name == value)
+
         value = bool(value)
         text = self.yesno[int(not value)]
         attrs = {"class": six.text_type(value).lower()}

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -346,6 +346,25 @@ class Accessor(str):
             return ()
         return self.split(self.SEPARATOR)
 
+    def get_field(self, context, quiet=False):
+        '''Return the django model field for model in context, following relations'''
+        try:
+            current = context
+            for bit in self.bits:
+                try:  # attribute lookup
+                    current = getattr(current, bit)
+                except (TypeError, AttributeError):
+                    raise ValueError(
+                        'Failed lookup for key [%s] in %r, when trying to call '
+                        'get_field for the accessor %s' % (bit, current, self)
+                    )
+                if hasattr(current, '_meta'):
+                    context = current
+            return context._meta.get_field(bit)
+        except:
+            if not quiet:
+                raise
+
 
 A = Accessor  # alias
 

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -6,6 +6,8 @@ from functools import total_ordering
 from itertools import chain
 
 import six
+from django import VERSION
+from django.db.models.fields import FieldDoesNotExist
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
@@ -346,24 +348,26 @@ class Accessor(str):
             return ()
         return self.split(self.SEPARATOR)
 
-    def get_field(self, context, quiet=False):
+    def get_field(self, model, quiet=False):
         '''Return the django model field for model in context, following relations'''
-        try:
-            current = context
-            for bit in self.bits:
-                try:  # attribute lookup
-                    current = getattr(current, bit)
-                except (TypeError, AttributeError):
-                    raise ValueError(
-                        'Failed lookup for key [%s] in %r, when trying to call '
-                        'get_field for the accessor %s' % (bit, current, self)
-                    )
-                if hasattr(current, '_meta'):
-                    context = current
-            return context._meta.get_field(bit)
-        except:
-            if not quiet:
-                raise
+        if not hasattr(model, '_meta'):
+            return
+
+        field = None
+        for bit in self.bits:
+            try:
+                if VERSION < (1, 8):
+                    # remove if support for django 1.7 is dropped.
+                    field, _, _, _ = model._meta.get_field_by_name(bit)
+                else:
+                    field = model._meta.get_field(bit)
+            except FieldDoesNotExist:
+                break
+            if hasattr(field, 'rel') and hasattr(field.rel, 'to'):
+                model = field.rel.to
+                continue
+
+        return field
 
 
 A = Accessor  # alias

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -64,6 +64,7 @@ class Occupation(models.Model):
         (True, 'Yes'),
         (False, 'No')
     ))
+
     def get_absolute_url(self):
         return reverse('occupation', args=(self.pk, ))
 

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -60,7 +60,10 @@ class PersonProxy(Person):
 class Occupation(models.Model):
     name = models.CharField(max_length=200)
     region = models.ForeignKey('Region', null=True)
-
+    boolean = models.BooleanField(default=True, choices=(
+        (True, 'Yes'),
+        (False, 'No')
+    ))
     def get_absolute_url(self):
         return reverse('occupation', args=(self.pk, ))
 

--- a/tests/columns/test_booleancolumn.py
+++ b/tests/columns/test_booleancolumn.py
@@ -96,17 +96,17 @@ def test_boolean_field_choices_spanning_relations():
 
     class Table(tables.Table):
         boolean = tables.BooleanColumn(accessor='occupation.boolean')
+
         class Meta:
             model = Person
-
 
     model_true = Occupation.objects.create(name='true-name', boolean=True)
     model_false = Occupation.objects.create(name='false-name', boolean=False)
 
     table = Table([
         Person(first_name='True', last_name='False', occupation=model_true),
-        Person(first_name='True', last_name='False',  occupation=model_false)
+        Person(first_name='True', last_name='False', occupation=model_false)
     ])
 
-    assert table.rows[0]['occupation'] == '<span class="true">✔</span>'
-    assert table.rows[1]['occupation'] == '<span class="false">✘</span>'
+    assert table.rows[0]['boolean'] == '<span class="true">✔</span>'
+    assert table.rows[1]['boolean'] == '<span class="false">✘</span>'

--- a/tests/columns/test_booleancolumn.py
+++ b/tests/columns/test_booleancolumn.py
@@ -89,27 +89,23 @@ def test_boolean_field_choices():
 
 
 def test_boolean_field_choices_with_real_model_instances():
-    BOOL_CHOICES=((True, "Yes"),
-                  (False, "No"))
-    
     class BoolModel(models.Model):
-        field = models.BooleanField(
-            choices=BOOL_CHOICES
+        field = models.BooleanField(choices=(
+            (True, 'Yes'),
+            (False, 'No'))
         )
 
-    class Meta:
-        app_label = 'django_tables2_test'
+        class Meta:
+            app_label = 'django_tables2_test'
 
     class Table(tables.Table):
         class Meta:
             model = BoolModel
 
-    tb_true=BoolModel(field=True)
-    tb_false=BoolModel(field=False)
-    
-    table = Table(data=[tb_true, tb_false])
+    table = Table(data=[
+        BoolModel(field=True),
+        BoolModel(field=False)
+    ])
 
     assert table.rows[0]['field'] == '<span class="true">✔</span>'
     assert table.rows[1]['field'] == '<span class="false">✘</span>'
-
-    

--- a/tests/columns/test_booleancolumn.py
+++ b/tests/columns/test_booleancolumn.py
@@ -86,3 +86,30 @@ def test_boolean_field_choices():
 
     assert table.rows[0]['field'] == '<span class="true">✔</span>'
     assert table.rows[1]['field'] == '<span class="false">✘</span>'
+
+
+def test_boolean_field_choices_with_real_model_instances():
+    BOOL_CHOICES=((True, "Yes"),
+                  (False, "No"))
+    
+    class BoolModel(models.Model):
+        field = models.BooleanField(
+            choices=BOOL_CHOICES
+        )
+
+    class Meta:
+        app_label = 'django_tables2_test'
+
+    class Table(tables.Table):
+        class Meta:
+            model = BoolModel
+
+    tb_true=BoolModel(field=True)
+    tb_false=BoolModel(field=False)
+    
+    table = Table(data=[tb_true, tb_false])
+
+    assert table.rows[0]['field'] == '<span class="true">✔</span>'
+    assert table.rows[1]['field'] == '<span class="false">✘</span>'
+
+    

--- a/tests/columns/test_templatecolumn.py
+++ b/tests/columns/test_templatecolumn.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-import pytest
 from django.template import Context
 
 import django_tables2 as tables
+import pytest
 
 
 def test_should_handle_context_on_table():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,14 +37,16 @@ def test_model_table():
     class OccupationTable(tables.Table):
         class Meta:
             model = Occupation
-    assert ["id", "name", "region"] == list(OccupationTable.base_columns.keys())
+
+    assert ['id', 'name', 'region', 'boolean'] == list(OccupationTable.base_columns.keys())
 
     class OccupationTable2(tables.Table):
         extra = tables.Column()
 
         class Meta:
             model = Occupation
-    assert ["id", "name", "region", "extra"] == list(OccupationTable2.base_columns.keys())
+
+    assert ['id', 'name', 'region', 'boolean', 'extra'] == list(OccupationTable2.base_columns.keys())
 
     # be aware here, we already have *models* variable, but we're importing
     # over the top
@@ -52,8 +54,8 @@ def test_model_table():
 
     class ComplexModel(models.Model):
         char = models.CharField(max_length=200)
-        fk = models.ForeignKey("self")
-        m2m = models.ManyToManyField("self")
+        fk = models.ForeignKey('self')
+        m2m = models.ManyToManyField('self')
 
         class Meta:
             app_label = 'django_tables2_test'
@@ -61,7 +63,7 @@ def test_model_table():
     class ComplexTable(tables.Table):
         class Meta:
             model = ComplexModel
-    assert ["id", "char", "fk"] == list(ComplexTable.base_columns.keys())
+    assert ['id', 'char', 'fk'] == list(ComplexTable.base_columns.keys())
 
 
 def test_mixins():
@@ -73,7 +75,7 @@ def test_mixins():
 
         class Meta:
             model = Occupation
-    assert ["extra", "id", "name", "region", "extra2"] == list(OccupationTable.base_columns.keys())
+    assert ['extra', 'id', 'name', 'region', 'boolean', 'extra2'] == list(OccupationTable.base_columns.keys())
 
 
 def test_column_verbose_name():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,10 +131,14 @@ def test_accessor_can_return_field():
     assert type(Accessor('foo').get_field(context)) == models.CharField
 
 
-def test_accessor_raises_when_doesnt_exist():
+def test_accessor_returns_None_when_doesnt_exist():
     context = AccessorTestModel(foo='bar')
-    with pytest.raises(ValueError):
-        Accessor('bar').get_field(context)
+    assert Accessor('bar').get_field(context) is None
+
+
+def test_accessor_returns_None_if_not_a_model():
+    context = {'bar': 234}
+    assert Accessor('bar').get_field(context) is None
 
 
 def test_attribute_dict_handles_escaping():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,11 @@
 # coding: utf-8
-# from attest import assert_hook, raises, Tests
+import pytest
 import six
+from django.db import models
+
 from django_tables2.utils import (Accessor, AttributeDict, OrderBy,
                                   OrderByTuple, Sequence, computed_values,
                                   segment)
-
-import pytest
 
 
 def test_orderbytuple():
@@ -116,22 +116,40 @@ def test_accessor_wont_honors_alters_data():
 
 def test_accessor_can_be_quiet():
     foo = {}
-    assert Accessor("bar").resolve(foo, quiet=True) is None
+    assert Accessor('bar').resolve(foo, quiet=True) is None
+
+
+class AccessorTestModel(models.Model):
+    foo = models.CharField(max_length=20)
+
+    class Meta:
+        app_label = 'django_tables2_test'
+
+
+def test_accessor_can_return_field():
+    context = AccessorTestModel(foo='bar')
+    assert type(Accessor('foo').get_field(context)) == models.CharField
+
+
+def test_accessor_raises_when_doesnt_exist():
+    context = AccessorTestModel(foo='bar')
+    with pytest.raises(ValueError):
+        Accessor('bar').get_field(context)
 
 
 def test_attribute_dict_handles_escaping():
-    x = AttributeDict({"x": '"\'x&'})
+    x = AttributeDict({'x': '"\'x&'})
     assert x.as_html() == 'x="&quot;&#39;x&amp;"'
 
 
 def test_compute_values_supports_shallow_structures():
-    x = computed_values({"foo": lambda: "bar"})
-    assert x == {"foo": "bar"}
+    x = computed_values({'foo': lambda: 'bar'})
+    assert x == {'foo': 'bar'}
 
 
 def test_compute_values_supports_nested_structures():
-    x = computed_values({"foo": lambda: {"bar": lambda: "baz"}})
-    assert x == {"foo": {"bar": "baz"}}
+    x = computed_values({'foo': lambda: {'bar': lambda: 'baz'}})
+    assert x == {'foo': {'bar': 'baz'}}
 
 
 def test_segment_should_return_all_candidates():


### PR DESCRIPTION
Refs #300, #290

This implements a fix for the failing tests as proposed by @onnokort. It's not really pretty though. What do you think @onnokort?

Also includes the test from #300.

## TODO
- [x] Use `Accessor.get_field()` in `BoundColumn.verbose_name`.
