### PR TITLE
Non-field based linkColumn only renders default value if lookup fails.

### DIFF
--- a/django_tables2/columns/emailcolumn.py
+++ b/django_tables2/columns/emailcolumn.py
@@ -12,10 +12,12 @@ class EmailColumn(BaseLinkColumn):
     """
     A subclass of `.BaseLinkColumn` that renders the cell value as a hyperlink.
 
-    It's common to have a email value in a row hyperlinked to other page.
+    It's common to have a email value in a row hyperlinked to another page.
 
-    :param  attrs: a `dict` of HTML attributes that are added to
-                   the rendered ``<a href="...">...</a>`` tag
+    :param  attrs: a `dict` of HTML attributes that are added to the rendered
+                   ``<a href="...">...</a>`` tag
+    :param   text: Either static text, or a callable. If set, this value will be
+                   used to render the text inside link instead of value (default)
 
     Example:
 
@@ -32,8 +34,12 @@ class EmailColumn(BaseLinkColumn):
             email = tables.EmailColumn()
 
     """
-    def render(self, value):
-        return self.render_link('mailto:%s' % value, text=value)
+    def render(self, record, value):
+        return self.render_link(
+            uri='mailto:{}'.format(value),
+            record=record,
+            value=value
+        )
 
     @classmethod
     def from_field(cls, field):

--- a/django_tables2/columns/linkcolumn.py
+++ b/django_tables2/columns/linkcolumn.py
@@ -119,7 +119,7 @@ class LinkColumn(BaseLinkColumn):
         self.args = args
         self.kwargs = kwargs
         self.current_app = current_app
-        self.text_value = text
+        self.text = text
 
     def compose_url(self, record, *args, **kwargs):
         '''Compose the url if the column is constructed with a viewname.'''
@@ -148,13 +148,12 @@ class LinkColumn(BaseLinkColumn):
         return reverse(viewname, **params)
 
     def render(self, value, record, bound_column):
-        text_value = value
-        if self.text_value:
-            text_value = self.text_value
-            if callable(text_value):
-                text_value = text_value(record)
+        if self.text:
+            value = self.text
+            if callable(value):
+                value = value(record)
 
-        return self.render_link(self.compose_url(record, bound_column), text=text_value)
+        return self.render_link(self.compose_url(record, bound_column), text=value)
 
 
 @library.register

--- a/django_tables2/columns/urlcolumn.py
+++ b/django_tables2/columns/urlcolumn.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
+
 from django.db import models
+
 from .base import library
 from .linkcolumn import BaseLinkColumn
 
@@ -10,21 +12,23 @@ class URLColumn(BaseLinkColumn):
     """
     Renders URL values as hyperlinks.
 
+    :param text: Either static text, or a callable. If set, this
+                 value will be used to render the text inside link
+                 instead of value (default)
+    :param attrs: Additional attributes for the ``<a>`` tag
+
     Example::
 
         >>> class CompaniesTable(tables.Table):
         ...     www = tables.URLColumn()
         ...
-        >>> table = CompaniesTable([{"www": "http://google.com"}])
-        >>> table.rows[0]["www"]
+        >>> table = CompaniesTable([{'www': 'http://google.com'}])
+        >>> table.rows[0].get_cell('www')
         u'<a href="http://google.com">http://google.com</a>'
 
-    Additional attributes for the ``<a>`` tag can be specified via
-    ``attrs['a']``.
-
     """
-    def render(self, value):
-        return self.render_link(value, value)
+    def render(self, record, value):
+        return self.render_link(value, record=record, value=value)
 
     @classmethod
     def from_field(cls, field):

--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -124,7 +124,7 @@ class BoundRow(object):
                 value = accessor.resolve(self.record)
             except Exception:
                 # we need to account for non-field based columns (issue #257)
-                if isinstance(bound_column.column, BaseLinkColumn):
+                if isinstance(bound_column.column, BaseLinkColumn) and isinstance(self.record, models.Model):
                     return self._call_render(bound_column)
 
         if value in bound_column.column.empty_values:

--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -124,7 +124,8 @@ class BoundRow(object):
                 value = accessor.resolve(self.record)
             except Exception:
                 # we need to account for non-field based columns (issue #257)
-                if isinstance(bound_column.column, BaseLinkColumn) and isinstance(self.record, models.Model):
+                is_linkcolumn = isinstance(bound_column.column, BaseLinkColumn)
+                if is_linkcolumn and bound_column.column.text is not None:
                     return self._call_render(bound_column)
 
         if value in bound_column.column.empty_values:

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -346,7 +346,7 @@ class Accessor(str):
             return ()
         return self.split(self.SEPARATOR)
 
-    def get_field(self, model, quiet=False):
+    def get_field(self, model):
         '''Return the django model field for model in context, following relations'''
         if not hasattr(model, '_meta'):
             return
@@ -362,6 +362,18 @@ class Accessor(str):
                 continue
 
         return field
+
+    def penultimate(self, context, quiet=True):
+        '''
+        Split the accessor on the right-most dot '.', return a tuple with:
+         - the resolved left part.
+         - the remainder
+
+        >>> Accessor('a.b.c').penultimate({'a': {'a': 1, 'b': {'c': 2, 'd': 4}}})
+        ({'c': 2, 'd': 4}, 'c')
+        '''
+        path, _, remainder = self.rpartition('.')
+        return A(path).resolve(context, quiet=quiet), remainder
 
 
 A = Accessor  # alias

--- a/django_tables2/utils.py
+++ b/django_tables2/utils.py
@@ -476,8 +476,8 @@ def computed_values(d):
 
     Simple example:
 
-        >>> compute_values({"foo": lambda: "bar"})
-        {"foo": "bar"}
+        >>> compute_values({'foo': lambda: 'bar'})
+        {'foo': 'bar'}
 
     Arbitrarily deep structures are supported. The logic is as follows:
 
@@ -488,17 +488,17 @@ def computed_values(d):
 
         >>> def parents():
         ...     return {
-        ...         "father": lambda: "Foo",
-        ...         "mother": "Bar"
+        ...         'father': lambda: 'Foo',
+        ...         'mother': 'Bar'
         ...      }
         ...
         >>> a = {
-        ...     "name": "Brad",
-        ...     "parents": parents
+        ...     'name': 'Brad',
+        ...     'parents': parents
         ... }
         ...
         >>> computed_values(a)
-        {"name": "Brad", "parents": {"father": "Foo", "mother": "Bar"}}
+        {'name': 'Brad', 'parents': {'father': 'Foo', 'mother': 'Bar'}}
 
     :rtype: dict
     """

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Report bugs at http://github.com/bradleyayers/django-tables2/issues
     pages/column-headers
     pages/pagination
     pages/custom-rendering
-    pages/query-string-fields	
+    pages/query-string-fields
     pages/column-attributes
     pages/builtin-columns
     pages/template-tags
@@ -40,7 +40,3 @@ Report bugs at http://github.com/bradleyayers/django-tables2/issues
     pages/upgrading-from-v1
     pages/glossary
     pages/internal
-
-
-
-

--- a/docs/pages/api-reference.rst
+++ b/docs/pages/api-reference.rst
@@ -99,7 +99,7 @@ API Reference
 
             This functionality is also available via the ``show_header``
             keyword argument to a table's constructor.
-            
+
     .. attribute:: exclude
 
         Defines which columns should be excluded from the table. This is useful

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -1,11 +1,10 @@
-# coding: utf-8
-try:
-    from django.conf.urls import url
-except ImportError:
-    from django.conf.urls.defaults import url
+from django.conf.urls import url
+
 from . import views
 
 urlpatterns = [
+    url(r'^people/delete/(?P<pk>\d+)/$', views.person, name='person_delete'),
+    url(r'^people/edit/(?P<pk>\d+)/$', views.person, name='person_edit'),
     url(r'^people/(?P<pk>\d+)/$', views.person, name='person'),
     url(r'^occupations/(?P<pk>\d+)/$', views.occupation, name='occupation'),
     url(r'^&\'"/(?P<pk>\d+)/$', lambda req: None, name='escaping'),

--- a/tests/columns/test_checkboxcolumn.py
+++ b/tests/columns/test_checkboxcolumn.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable=R0912,E0102
 from __future__ import unicode_literals
 
 import django_tables2 as tables

--- a/tests/columns/test_datecolumn.py
+++ b/tests/columns/test_datecolumn.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable=R0912,E0102
 from __future__ import unicode_literals
 
 from datetime import date

--- a/tests/columns/test_datetimecolumn.py
+++ b/tests/columns/test_datetimecolumn.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable=R0912,E0102
 from __future__ import unicode_literals
 
 from datetime import datetime
@@ -10,10 +9,6 @@ from django.db import models
 
 import django_tables2 as tables
 
-try:
-    from django.utils import timezone
-except ImportError:
-    timezone = None
 
 # Format string: https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
 # D -- Day of the week, textual, 3 letters  -- 'Fri'
@@ -26,12 +21,7 @@ except ImportError:
 @pytest.yield_fixture
 def dt():
     dt = datetime(2012, 9, 11, 12, 30, 0)
-    if timezone:
-        # If the version of Django has timezone support, convert from naive to
-        # UTC, the test project uses Australia/Brisbane so regardless the
-        # output from the column should be the same.
-        dt = pytz.timezone('Australia/Brisbane').localize(dt)
-    yield dt
+    yield pytz.timezone('Australia/Brisbane').localize(dt)
 
 
 def test_should_handle_explicit_format(dt):

--- a/tests/columns/test_emailcolumn.py
+++ b/tests/columns/test_emailcolumn.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable=R0912,E0102
 from __future__ import unicode_literals
 
 from django.db import models

--- a/tests/columns/test_emailcolumn.py
+++ b/tests/columns/test_emailcolumn.py
@@ -5,11 +5,6 @@ from django.db import models
 
 import django_tables2 as tables
 
-try:
-    from django.utils import timezone
-except ImportError:
-    timezone = None
-
 
 def test_should_turn_email_address_into_hyperlink():
     class Table(tables.Table):
@@ -27,7 +22,7 @@ def test_should_render_default_for_blank():
     assert table.rows[0].get_cell('email') == '---'
 
 
-def test_should_be_used_for_datetimefields():
+def test_should_be_used_for_emailfields():
     class EmailModel(models.Model):
         field = models.EmailField()
 
@@ -39,3 +34,11 @@ def test_should_be_used_for_datetimefields():
             model = EmailModel
 
     assert type(Table.base_columns['field']) == tables.EmailColumn
+
+
+def test_text_should_be_overridable():
+    class Table(tables.Table):
+        email = tables.EmailColumn(text='@')
+
+    table = Table([{'email': 'test@example.com'}])
+    assert table.rows[0].get_cell('email') == '<a href="mailto:test@example.com">@</a>'

--- a/tests/columns/test_filecolumn.py
+++ b/tests/columns/test_filecolumn.py
@@ -1,16 +1,15 @@
 # coding: utf-8
-# pylint: disable=R0912,E0102
 from __future__ import unicode_literals
 
 from os.path import dirname, join
 
+import pytest
 from django.core.files.base import ContentFile
 from django.core.files.storage import FileSystemStorage
 from django.db import models
 from django.db.models.fields.files import FieldFile
 
 import django_tables2 as tables
-import pytest
 
 from ..utils import parse
 

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable=R0912,E0102
 from __future__ import unicode_literals
 
 import pytest
@@ -87,13 +86,12 @@ def test_handle_verbose_name_of_many2onerel():
 
 
 def test_orderable():
-    # Table.Meta.orderable = False
     class SimpleTable(tables.Table):
         name = tables.Column()
+
     table = SimpleTable([])
     assert table.columns['name'].orderable is True
 
-    # Table.Meta.orderable = False
     class SimpleTable(tables.Table):
         name = tables.Column()
 
@@ -102,48 +100,48 @@ def test_orderable():
     table = SimpleTable([])
     assert table.columns['name'].orderable is False
 
-    # Table.Meta.orderable = True
     class SimpleTable(tables.Table):
         name = tables.Column()
 
         class Meta:
             orderable = True
+
     table = SimpleTable([])
     assert table.columns['name'].orderable is True
 
 
 def test_order_by_defaults_to_accessor():
     class SimpleTable(tables.Table):
-        foo = tables.Column(accessor="bar")
+        foo = tables.Column(accessor='bar')
 
     table = SimpleTable([])
-    assert table.columns["foo"].order_by == ("bar", )
+    assert table.columns['foo'].order_by == ('bar', )
 
 
 def test_supports_order_by():
     class SimpleTable(tables.Table):
-        name = tables.Column(order_by=("last_name", "-first_name"))
+        name = tables.Column(order_by=('last_name', '-first_name'))
         age = tables.Column()
 
-    table = SimpleTable([], order_by=("-age", ))
+    table = SimpleTable([], order_by=('-age', ))
     # alias
-    assert table.columns["name"].order_by_alias == "name"
-    assert table.columns["age"].order_by_alias == "-age"
+    assert table.columns['name'].order_by_alias == 'name'
+    assert table.columns['age'].order_by_alias == '-age'
     # order by
-    assert table.columns["name"].order_by == ("last_name", "-first_name")
-    assert table.columns["age"].order_by == ("-age", )
+    assert table.columns['name'].order_by == ('last_name', '-first_name')
+    assert table.columns['age'].order_by == ('-age', )
 
     # now try with name ordered
-    table = SimpleTable([], order_by=("-name", ))
+    table = SimpleTable([], order_by=('-name', ))
     # alias
-    assert table.columns["name"].order_by_alias == "-name"
-    assert table.columns["age"].order_by_alias == "age"
+    assert table.columns['name'].order_by_alias == '-name'
+    assert table.columns['age'].order_by_alias == 'age'
     # alias next
-    assert table.columns["name"].order_by_alias.next == "name"
-    assert table.columns["age"].order_by_alias.next == "age"
+    assert table.columns['name'].order_by_alias.next == 'name'
+    assert table.columns['age'].order_by_alias.next == 'age'
     # order by
-    assert table.columns["name"].order_by == ("-last_name", "first_name")
-    assert table.columns["age"].order_by == ("age", )
+    assert table.columns['name'].order_by == ('-last_name', 'first_name')
+    assert table.columns['age'].order_by == ('age', )
 
 
 def test_supports_is_ordered():
@@ -152,10 +150,10 @@ def test_supports_is_ordered():
 
     # sorted
     table = SimpleTable([], order_by='name')
-    assert table.columns["name"].is_ordered
+    assert table.columns['name'].is_ordered
     # unsorted
     table = SimpleTable([])
-    assert not table.columns["name"].is_ordered
+    assert not table.columns['name'].is_ordered
 
 
 def test_translation():
@@ -164,10 +162,10 @@ def test_translation():
     column.
     """
     class TranslationTable(tables.Table):
-        text = tables.Column(verbose_name=ugettext_lazy("Text"))
+        text = tables.Column(verbose_name=ugettext_lazy('Text'))
 
     table = TranslationTable([])
-    assert "Text" == table.columns["text"].header
+    assert 'Text' == table.columns['text'].header
 
 
 def test_sequence():
@@ -178,44 +176,44 @@ def test_sequence():
         a = tables.Column()
         b = tables.Column()
         c = tables.Column()
-    assert ["a", "b", "c"] == TestTable([]).columns.names()
-    assert ["b", "a", "c"] == TestTable([], sequence=("b", "a", "c")).columns.names()
+    assert ['a', 'b', 'c'] == TestTable([]).columns.names()
+    assert ['b', 'a', 'c'] == TestTable([], sequence=('b', 'a', 'c')).columns.names()
 
     class TestTable2(TestTable):
         class Meta:
-            sequence = ("b", "a", "c")
-    assert ["b", "a", "c"] == TestTable2([]).columns.names()
-    assert ["a", "b", "c"] == TestTable2([], sequence=("a", "b", "c")).columns.names()
+            sequence = ('b', 'a', 'c')
+    assert ['b', 'a', 'c'] == TestTable2([]).columns.names()
+    assert ['a', 'b', 'c'] == TestTable2([], sequence=('a', 'b', 'c')).columns.names()
 
     class TestTable3(TestTable):
         class Meta:
-            sequence = ("c", )
-    assert ["c", "a", "b"] == TestTable3([]).columns.names()
-    assert ["c", "a", "b"] == TestTable([], sequence=("c", )).columns.names()
+            sequence = ('c', )
+    assert ['c', 'a', 'b'] == TestTable3([]).columns.names()
+    assert ['c', 'a', 'b'] == TestTable([], sequence=('c', )).columns.names()
 
     class TestTable4(TestTable):
         class Meta:
-            sequence = ("...", )
-    assert ["a", "b", "c"] == TestTable4([]).columns.names()
-    assert ["a", "b", "c"] == TestTable([], sequence=("...", )).columns.names()
+            sequence = ('...', )
+    assert ['a', 'b', 'c'] == TestTable4([]).columns.names()
+    assert ['a', 'b', 'c'] == TestTable([], sequence=('...', )).columns.names()
 
     class TestTable5(TestTable):
         class Meta:
-            sequence = ("b", "...")
-    assert ["b", "a", "c"] == TestTable5([]).columns.names()
-    assert ["b", "a", "c"] == TestTable([], sequence=("b", "...")).columns.names()
+            sequence = ('b', '...')
+    assert ['b', 'a', 'c'] == TestTable5([]).columns.names()
+    assert ['b', 'a', 'c'] == TestTable([], sequence=('b', '...')).columns.names()
 
     class TestTable6(TestTable):
         class Meta:
-            sequence = ("...", "b")
-    assert ["a", "c", "b"] == TestTable6([]).columns.names()
-    assert ["a", "c", "b"] == TestTable([], sequence=("...", "b")).columns.names()
+            sequence = ('...', 'b')
+    assert ['a', 'c', 'b'] == TestTable6([]).columns.names()
+    assert ['a', 'c', 'b'] == TestTable([], sequence=('...', 'b')).columns.names()
 
     class TestTable7(TestTable):
         class Meta:
-            sequence = ("b", "...", "a")
-    assert ["b", "c", "a"] == TestTable7([]).columns.names()
-    assert ["b", "c", "a"] == TestTable([], sequence=("b", "...", "a")).columns.names()
+            sequence = ('b', '...', 'a')
+    assert ['b', 'c', 'a'] == TestTable7([]).columns.names()
+    assert ['b', 'c', 'a'] == TestTable([], sequence=('b', '...', 'a')).columns.names()
 
     # Let's test inheritence
     class TestTable8(TestTable):
@@ -224,15 +222,15 @@ def test_sequence():
         f = tables.Column()
 
         class Meta:
-            sequence = ("d", "...")
+            sequence = ('d', '...')
 
     class TestTable9(TestTable):
         d = tables.Column()
         e = tables.Column()
         f = tables.Column()
 
-    assert ["d", "a", "b", "c", "e", "f"] == TestTable8([]).columns.names()
-    assert ["d", "a", "b", "c", "e", "f"] == TestTable9([], sequence=("d", "...")).columns.names()
+    assert ['d', 'a', 'b', 'c', 'e', 'f'] == TestTable8([]).columns.names()
+    assert ['d', 'a', 'b', 'c', 'e', 'f'] == TestTable9([], sequence=('d', '...')).columns.names()
 
 
 def test_should_support_both_meta_sequence_and_constructor_exclude():
@@ -265,24 +263,24 @@ def test_bound_columns_should_support_indexing():
 
 def test_cell_attrs_applies_to_td_and_th():
     class SimpleTable(tables.Table):
-        a = tables.Column(attrs={"cell": {"key": "value"}})
+        a = tables.Column(attrs={'cell': {'key': 'value'}})
 
     # providing data ensures 1 row is rendered
-    table = SimpleTable([{"a": "value"}])
+    table = SimpleTable([{'a': 'value'}])
     root = parse(table.as_html(request))
 
-    assert root.findall('.//thead/tr/th')[0].attrib == {"key": "value", "class": "a orderable"}
-    assert root.findall('.//tbody/tr/td')[0].attrib == {"key": "value", "class": "a"}
+    assert root.findall('.//thead/tr/th')[0].attrib == {'key': 'value', 'class': 'a orderable'}
+    assert root.findall('.//tbody/tr/td')[0].attrib == {'key': 'value', 'class': 'a'}
 
 
 def test_cells_are_automatically_given_column_name_as_class():
     class SimpleTable(tables.Table):
         a = tables.Column()
 
-    table = SimpleTable([{"a": "value"}])
+    table = SimpleTable([{'a': 'value'}])
     root = parse(table.as_html(request))
-    assert root.findall('.//thead/tr/th')[0].attrib == {"class": "a orderable"}
-    assert root.findall('.//tbody/tr/td')[0].attrib == {"class": "a"}
+    assert root.findall('.//thead/tr/th')[0].attrib == {'class': 'a orderable'}
+    assert root.findall('.//tbody/tr/td')[0].attrib == {'class': 'a'}
 
 
 def test_th_are_given_orderable_class_if_column_is_orderable():
@@ -290,25 +288,25 @@ def test_th_are_given_orderable_class_if_column_is_orderable():
         a = tables.Column()
         b = tables.Column(orderable=False)
 
-    table = SimpleTable([{"a": "value"}])
+    table = SimpleTable([{'a': 'value'}])
     root = parse(table.as_html(request))
     # return classes of an element as a set
-    classes = lambda x: set(x.attrib["class"].split())
-    assert "orderable" in classes(root.findall('.//thead/tr/th')[0])
-    assert "orderable" not in classes(root.findall('.//thead/tr/th')[1])
+    classes = lambda x: set(x.attrib['class'].split())
+    assert 'orderable' in classes(root.findall('.//thead/tr/th')[0])
+    assert 'orderable' not in classes(root.findall('.//thead/tr/th')[1])
 
     # Now try with an ordered table
-    table = SimpleTable([], order_by="a")
+    table = SimpleTable([], order_by='a')
     root = parse(table.as_html(request))
     # return classes of an element as a set
-    assert "orderable" in classes(root.findall('.//thead/tr/th')[0])
-    assert "asc" in classes(root.findall('.//thead/tr/th')[0])
-    assert "orderable" not in classes(root.findall('.//thead/tr/th')[1])
+    assert 'orderable' in classes(root.findall('.//thead/tr/th')[0])
+    assert 'asc' in classes(root.findall('.//thead/tr/th')[0])
+    assert 'orderable' not in classes(root.findall('.//thead/tr/th')[1])
 
 
 def test_empty_values_triggers_default():
     class Table(tables.Table):
-        a = tables.Column(empty_values=(1, 2), default="--")
+        a = tables.Column(empty_values=(1, 2), default='--')
 
     table = Table([{'a': 1}, {'a': 2}, {'a': 3}, {'a': 4}])
     assert [row.get_cell('a') for row in table.rows] == ['--', '--', 3, 4]

--- a/tests/columns/test_linkcolumn.py
+++ b/tests/columns/test_linkcolumn.py
@@ -139,12 +139,12 @@ def test_a_attrs_should_be_supported():
     }
 
 
-# def test_defaults():
-#     class Table(tables.Table):
-#         link = tables.LinkColumn('occupation', kwargs={'pk': 1}, default='xyz')
-#
-#     table = Table([{}])
-#     assert table.rows[0].get_cell('link') == 'xyz'
+def test_defaults():
+    class Table(tables.Table):
+        link = tables.LinkColumn('occupation', kwargs={'pk': 1}, default='xyz')
+
+    table = Table([{}])
+    assert table.rows[0].get_cell('link') == 'xyz'
 
 
 @pytest.mark.django_db

--- a/tests/columns/test_linkcolumn.py
+++ b/tests/columns/test_linkcolumn.py
@@ -58,7 +58,7 @@ def test_link_text_custom_value():
 
 def test_link_text_escaping():
     class CustomLinkTable(tables.Table):
-        last_name = tables.LinkColumn(
+        editlink = tables.LinkColumn(
             'person',
             text=mark_safe('edit'),
             args=[A('pk')]
@@ -71,7 +71,7 @@ def test_link_text_escaping():
     table = CustomLinkTable(dataset)
     html = table.as_html(build_request('/some-url/'))
 
-    expected = '<td class="last_name"><a href="{}">edit</a></td>'.format(
+    expected = '<td class="editlink"><a href="{}">edit</a></td>'.format(
         reverse('person', args=(1, ))
     )
     assert expected in html

--- a/tests/columns/test_linkcolumn.py
+++ b/tests/columns/test_linkcolumn.py
@@ -87,9 +87,10 @@ def test_null_foreign_key():
 
     Person.objects.create(first_name='bradley', last_name='ayers')
 
-    request = build_request()
     table = PersonTable(Person.objects.all())
-    table.as_html(request)
+    html = table.as_html(build_request())
+
+    assert '<td class="occupation">—</td>' in html
 
 
 def test_kwargs():

--- a/tests/columns/test_timecolumn.py
+++ b/tests/columns/test_timecolumn.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable=R0912,E0102
 from __future__ import unicode_literals
 
 from datetime import time
@@ -14,10 +13,10 @@ import django_tables2 as tables
 
 def test_should_handle_explicit_format():
     class TestTable(tables.Table):
-        time = tables.TimeColumn(format="H:i:s")
+        time = tables.TimeColumn(format='H:i:s')
 
         class Meta:
-            default = "—"
+            default = '—'
 
     table = TestTable([{'time': time(11, 11, 11)},
                        {'time': None}])
@@ -36,4 +35,4 @@ def test_should_be_used_for_timefields():
         class Meta:
             model = TimeModel
 
-    assert type(Table.base_columns["field"]) == tables.TimeColumn
+    assert type(Table.base_columns['field']) == tables.TimeColumn

--- a/tests/columns/test_urlcolumn.py
+++ b/tests/columns/test_urlcolumn.py
@@ -5,6 +5,12 @@ from django.db import models
 
 import django_tables2 as tables
 
+MEMORY_DATA = [
+    {'url': 'http://example.com', 'name': 'Example'},
+    {'url': 'https://example.com', 'name': 'Example (https)'},
+    {'url': 'ftp://example.com', 'name': 'Example (ftp)'},
+]
+
 
 def test_should_turn_url_into_hyperlink():
     class TestTable(tables.Table):
@@ -27,3 +33,21 @@ def test_should_be_used_for_urlfields():
             model = URLModel
 
     assert type(Table.base_columns['field']) == tables.URLColumn
+
+
+def test_text_can_be_overridden():
+    class Table(tables.Table):
+        url = tables.URLColumn(text='link')
+
+    table = Table([{'url': 'http://example.com'}])
+
+    assert table.rows[0].get_cell('url') == '<a href="http://example.com">link</a>'
+
+
+def test_text_can_be_overridden_with_callable():
+    class Table(tables.Table):
+        url = tables.URLColumn(text=lambda record: record['name'])
+
+    table = Table(MEMORY_DATA)
+
+    assert table.rows[0].get_cell('url') == '<a href="http://example.com">Example</a>'

--- a/tests/columns/test_urlcolumn.py
+++ b/tests/columns/test_urlcolumn.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# pylint: disable=R0912,E0102
 from __future__ import unicode_literals
 
 from django.db import models
@@ -27,4 +26,4 @@ def test_should_be_used_for_urlfields():
         class Meta:
             model = URLModel
 
-    assert type(Table.base_columns["field"]) == tables.URLColumn
+    assert type(Table.base_columns['field']) == tables.URLColumn

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,33 +37,33 @@ def test_orderbytuple():
 def test_orderbytuple_sort_key_multiple():
     obt = OrderByTuple(('a', '-b'))
     items = [
-        {"a": 1, "b": 2},
-        {"a": 1, "b": 3},
+        {'a': 1, 'b': 2},
+        {'a': 1, 'b': 3},
     ]
     assert sorted(items, key=obt.key) == [
-        {"a": 1, "b": 3},
-        {"a": 1, "b": 2},
+        {'a': 1, 'b': 3},
+        {'a': 1, 'b': 2},
     ]
 
 
 def test_orderbytuple_sort_key_empty_comes_first():
     obt = OrderByTuple(('a'))
     items = [
-        {"a": 1},
-        {"a": ""},
-        {"a": 2},
+        {'a': 1},
+        {'a': ''},
+        {'a': 2},
     ]
     if six.PY3:
         assert sorted(items, key=obt.key) == [
-            {"a": ""},
-            {"a": 1},
-            {"a": 2},
+            {'a': ''},
+            {'a': 1},
+            {'a': 2},
         ]
     else:
         assert sorted(items, key=obt.key) == [
-            {"a": 1},
-            {"a": 2},
-            {"a": ""},
+            {'a': 1},
+            {'a': 2},
+            {'a': ''},
         ]
 
 
@@ -158,12 +158,12 @@ def test_compute_values_supports_nested_structures():
 
 def test_segment_should_return_all_candidates():
     assert set(segment(("a", "-b", "c"), {
-        "x": "a",
-        "y": ("b", "-c"),
-        "-z": ("b", "-c"),
+        'x': 'a',
+        'y': ('b', '-c'),
+        '-z': ('b', '-c'),
     })) == {
-        ("x", "-y"),
-        ("x", "z"),
+        ('x', '-y'),
+        ('x', 'z'),
     }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,6 +141,22 @@ def test_accessor_returns_None_if_not_a_model():
     assert Accessor('bar').get_field(context) is None
 
 
+def test_accessor_penultimate():
+    context = {
+        'a': {
+            'a': 1,
+            'b': {
+                'c': 2,
+                'd': 4
+            }
+        }
+    }
+
+    assert Accessor('a.b.c').penultimate(context) == (context['a']['b'], 'c')
+
+    assert Accessor('a.b.c.d.e').penultimate(context) == (None, 'e')
+
+
 def test_attribute_dict_handles_escaping():
     x = AttributeDict({'x': '"\'x&'})
     assert x.as_html() == 'x="&quot;&#39;x&amp;"'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,11 @@
 # coding: utf-8
+import pytest
 from django.db import models
 from django.utils import six
 
-import pytest
 from django_tables2.utils import (Accessor, AttributeDict, OrderBy,
                                   OrderByTuple, Sequence, computed_values,
-                                  segment)
+                                  segment, signature)
 
 
 def test_orderbytuple():
@@ -172,3 +172,46 @@ def test_sequence_multiple_ellipsis():
 
     with pytest.raises(ValueError):
         sequence.expand(['foo'])
+
+
+def test_signature():
+    def foo(bar, baz):
+        pass
+
+    args, keywords = signature(foo)
+    assert args == ('bar', 'baz')
+    assert keywords is None
+
+
+def test_signature_method():
+    class Foo(object):
+        def foo(self):
+            pass
+
+        def bar(self, bar, baz):
+            pass
+
+        def baz(self, bar, *bla, **boo):
+            pass
+
+    obj = Foo()
+    args, keywords = signature(obj.foo)
+    assert args == ()
+    assert keywords is None
+
+    args, keywords = signature(obj.bar)
+    assert args == ('bar', 'baz')
+    assert keywords is None
+
+    args, keywords = signature(obj.baz)
+    assert args == ('bar', )
+    assert keywords == 'boo'
+
+
+def test_signature_catch_all_kwargs():
+    def foo(bar, baz, **kwargs):
+        pass
+
+    args, keywords = signature(foo)
+    assert args == ('bar', 'baz')
+    assert keywords == 'kwargs'


### PR DESCRIPTION
Should not render de default dash when used with 

```python
class Table(tables.Table):
    delete_link = tables.LinkColumn(
        'order_delete',
        kwargs={'customer_pk': tables.A('customer.id'), 'pk': tables.A('id')}
    )
```

This is still WIP, I'm trying to work out a sane API and try to think of all the edge cases.

Fixes #257, Quite a lot of unrelated changes, sorry.
