### PR TITLE
Column ordering queryset passthrough

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -244,7 +244,7 @@ class Column(object):
         Returns the queryset of the table.
 
         This method can be overridden by :ref:`table.order_FOO` methods on the
-        table or by subclassing `.Column`. Only overrides if second element
+        table or by subclassing `.Column`; but only overrides if second element
         in return tuple is True.
 
         :returns: Tuple (queryset, boolean)

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -239,6 +239,18 @@ class Column(object):
         """
         return value
 
+    def order(self, queryset, is_descending):
+        """
+        Returns the queryset of the table.
+
+        This method can be overridden by :ref:`table.order_FOO` methods on the
+        table or by subclassing `.Column`. Only overrides if second element
+        in return tuple is True.
+
+        :returns: Tuple (queryset, boolean)
+        """
+        return (queryset, False)
+
     @classmethod
     def from_field(cls, field):
         """
@@ -527,6 +539,7 @@ class BoundColumns(object):
         for name, column in six.iteritems(table.base_columns):
             self.columns[name] = bc = BoundColumn(table, column, name)
             bc.render = getattr(table, 'render_' + name, column.render)
+            bc.order = getattr(table, 'order_' + name, column.order)
 
     def iternames(self):
         return (name for name, column in self.iteritems())

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -91,6 +91,7 @@ class TableData(object):
                         regard to data ordering.
         :type  aliases: `~.utils.OrderByTuple`
         """
+        bound_column = None
         accessors = []
         for alias in aliases:
             bound_column = self.table.columns[OrderBy(alias).bare]
@@ -104,8 +105,8 @@ class TableData(object):
         if hasattr(self, 'queryset'):
             # Custom ordering
             if bound_column:
-                self.queryset, custom = bound_column.order(self.queryset, alias[0] == '-')
-                if custom:
+                self.queryset, modified = bound_column.order(self.queryset, alias[0] == '-')
+                if modified:
                     return
             # Traditional ordering
             translate = lambda accessor: accessor.replace(Accessor.SEPARATOR, QUERYSET_ACCESSOR_SEPARATOR)

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -102,6 +102,12 @@ class TableData(object):
             else:
                 accessors += bound_column.order_by
         if hasattr(self, 'queryset'):
+            # Custom ordering
+            if bound_column:
+                self.queryset, custom = bound_column.order(self.queryset, alias[0] == '-')
+                if custom:
+                    return
+            # Traditional ordering
             translate = lambda accessor: accessor.replace(Accessor.SEPARATOR, QUERYSET_ACCESSOR_SEPARATOR)
             if accessors:
                 self.queryset = self.queryset.order_by(*(translate(a) for a in accessors))

--- a/docs/pages/order-by-accessors.rst
+++ b/docs/pages/order-by-accessors.rst
@@ -85,7 +85,7 @@ The implementation would look like this:
 
 
 As another example, presume the situation calls for being able to order by a
-mathematical expression. In this predicament, the table needs to be able to be
+mathematical expression. In this scenario, the table needs to be able to be
 ordered by the sum of both the shirts and the pants. The custom column will
 have its value rendered using :ref:`table.render_FOO`.
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -302,6 +302,7 @@ def test_queryset_table_data_supports_custom_ordering():
     class Table(tables.Table):
         class Meta:
             model = Person
+            order_by = 'first_name'
 
         def order_first_name(self, queryset, is_descending):
             # annotate to order by length of first_name + last_name

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import pytest
 from django.utils import six
+from django.db.models.functions import Length
 
 import django_tables2 as tables
 
@@ -295,6 +296,32 @@ def test_queryset_table_data_supports_ordering():
     assert table.rows[0].get_cell('first_name') == 'Bradley'
     table.order_by = '-first_name'
     assert table.rows[0].get_cell('first_name') == 'Stevie'
+
+
+def test_queryset_table_data_supports_custom_ordering():
+    class Table(tables.Table):
+        class Meta:
+            model = Person
+
+        def order_first_name(self, queryset, is_descending):
+            # annotate to order by length of first_name + last_name
+            queryset = queryset.annotate(
+                length=Length("first_name") + Length("last_name")
+            ).order_by(('-' if is_descending else '') + 'length')
+            return (queryset, True)
+
+    for name in ('Bradley Ayers', 'Stevie Armstrong', 'VeryLongFirstName VeryLongLastName'):
+        first_name, last_name = name.split()
+        Person.objects.create(first_name=first_name, last_name=last_name)
+
+    table = Table(Person.objects.all())
+
+    # Shortest full names first
+    assert table.rows[0].get_cell('first_name') == 'Bradley'
+
+    # Longest full names first
+    table.order_by = '-first_name'
+    assert table.rows[0].get_cell('first_name') == 'VeryLongFirstName'
 
 
 def test_doesnotexist_from_accessor_should_use_default():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -306,7 +306,7 @@ def test_queryset_table_data_supports_custom_ordering():
         def order_first_name(self, queryset, is_descending):
             # annotate to order by length of first_name + last_name
             queryset = queryset.annotate(
-                length=Length("first_name") + Length("last_name")
+                length=Length('first_name') + Length('last_name')
             ).order_by(('-' if is_descending else '') + 'length')
             return (queryset, True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ usedevelop = true
 pip_pre = true
 setenv = PYTHONPATH={toxinidir}
 commands =
-    py.test --cov=django_tables2 --cov-report term-missing
+    py.test tests --cov=django_tables2 --cov-report term-missing
     flake8
 
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ usedevelop = true
 pip_pre = true
 setenv = PYTHONPATH={toxinidir}
 commands =
-    py.test tests --cov=django_tables2 --cov-report term-missing
+    py.test --cov=django_tables2 --cov-report term-missing
     flake8
 
 deps =


### PR DESCRIPTION
Queryset passes through function to be tinkered with when a column is
sorted.

Similar to `render_FOO`

Example Usage:
```python
def order_success_rate(self, queryset, is_descending):
    # Custom queryset ordering that uses the database to calculate the
    # success rate of a webpage game
    queryset = queryset.extra(
        select={'value': '(clicks / completed) * 100'},
        order_by=(('-' if is_descending else '') + 'value',)
    )

    # Tuple of reordered queryset and a boolean marking as reordered so it will
    # override the order of the column
    return (queryset, True)
```
