### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ About the app:
 
 - `Available on pypi <https://pypi.python.org/pypi/django-tables2>`_
 - Tested with python 2.7, 3.3, 3.4, 3.5 and Django 1.8, 1.9, `Travis CI <https://travis-ci.org/bradleyayers/django-tables2>`_
-- `Documentation on readthedocs.org <http://django-tables2.readthedocs.org/en/latest/>`_
+- `Documentation on readthedocs.org <https://django-tables2.readthedocs.io/en/latest/>`_
 - `Bug tracker <http://github.com/bradleyayers/django-tables2/issues>`_
 
 Example
@@ -73,4 +73,4 @@ And finally in the template:
     {% render_table table %}
 
 This example shows one of the simplest cases, but django-tables2 can do a lot more!
-Check out the _documentation: http://django-tables2.readthedocs.org/en/latest/ for more details.
+Check out the _documentation: https://django-tables2.readthedocs.io/en/latest/ for more details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ About the app:
 
 - `Available on pypi <https://pypi.python.org/pypi/django-tables2>`_
 - Tested with python 2.7, 3.3, 3.4, 3.5 and Django 1.8, 1.9, `Travis CI <https://travis-ci.org/bradleyayers/django-tables2>`_
-- `Documentation on readthedocs.org <http://django-tables2.readthedocs.org/en/latest/>`_
+- `Documentation on readthedocs.org <https://django-tables2.readthedocs.io/en/latest/>`_
 - `Bug tracker <http://github.com/bradleyayers/django-tables2/issues>`_
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.