### PR TITLE
Preserve column options over inheritance

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -92,9 +92,13 @@ class Column(object):
 
     .. [1] The provided callable object must not expect to receive any arguments.
     """
-    #: Tracks each time a Column instance is created. Used to retain order.
+    # Tracks each time a Column instance is created. Used to retain order.
     creation_counter = 0
     empty_values = (None, '')
+
+    # Explicit is set to True if the column is defined as an attribute of a
+    # class, used to give explicit columns precedence.
+    _explicit = False
 
     def __init__(self, verbose_name=None, accessor=None, default=None,
                  visible=True, orderable=None, attrs=None, order_by=None,

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -150,11 +150,11 @@ class TableData(object):
 
 
 class DeclarativeColumnsMetaclass(type):
-    """
+    '''
     Metaclass that converts `.Column` objects defined on a class to the
     dictionary `.Table.base_columns`, taking into account parent class
-    ``base_columns`` as well.
-    """
+    `base_columns` as well.
+    '''
     def __new__(mcs, name, bases, attrs):
         attrs['_meta'] = opts = TableOptions(attrs.get('Meta', None))
         # extract declared columns
@@ -203,14 +203,15 @@ class DeclarativeColumnsMetaclass(type):
         for exclusion in opts.exclude:
             if exclusion in attrs['base_columns']:
                 attrs['base_columns'].pop(exclusion)
-        # Now reorder the columns based on explicit sequence
+
+        # Reorder the columns based on explicit sequence
         if opts.sequence:
             opts.sequence.expand(attrs['base_columns'].keys())
             # Table's sequence defaults to sequence declared in Meta
             # attrs['_sequence'] = opts.sequence
             attrs['base_columns'] = OrderedDict(((x, attrs['base_columns'][x]) for x in opts.sequence))
 
-        # set localize on columns
+        # Set localize on columns
         for col_name in attrs['base_columns'].keys():
             localize_column = None
             if col_name in opts.localize:

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -338,6 +338,21 @@ def test_raises_when_using_non_supported_index():
         row[table]
 
 
+class MyModel(models.Model):
+    item1 = models.CharField(max_length=10)
+
+    class Meta:
+        app_label = 'django_tables2_tests'
+
+
+class MyTable(tables.Table):
+    item1 = tables.Column(verbose_name='Nice column name')
+
+    class Meta:
+        model = MyModel
+        fields = ('item1', )
+
+
 def test_column_params_should_be_preserved_under_inheritance():
     '''
     Github issue #337
@@ -347,18 +362,6 @@ def test_column_params_should_be_preserved_under_inheritance():
     If the column is not redefined, the explicit definition of MyTable is used,
     preserving the specialized verbose_name defined on it.
     '''
-    class MyModel(models.Model):
-        item1 = models.CharField(max_length=10)
-
-        class Meta:
-            app_label = 'django_tables2_tests'
-
-    class MyTable(tables.Table):
-        item1 = tables.Column(verbose_name='Nice column name')
-
-        class Meta:
-            model = MyModel
-            fields = ('item1', )
 
     class MyTableA(MyTable):
         '''
@@ -383,3 +386,17 @@ def test_column_params_should_be_preserved_under_inheritance():
     assert table.columns['item1'].verbose_name == 'Nice column name'
     assert tableA.columns['item1'].verbose_name == 'Nice column name'
     assert tableB.columns['item1'].verbose_name == 'Nice column name'
+
+
+def test_explicit_column_can_be_overridden_by_other_explicit_column():
+    class MyTableC(MyTable):
+        '''
+        If we define a new explict item1 column, that one should be used.
+        '''
+        item1 = tables.Column(verbose_name='New nice column name')
+
+    table = MyTable(MyModel.objects.all())
+    tableC = MyTableC(MyModel.objects.all())
+
+    assert table.columns['item1'].verbose_name == 'Nice column name'
+    assert tableC.columns['item1'].verbose_name == 'New nice column name'

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -1,12 +1,12 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-import pytest
 from django.db import models
 from django.utils.safestring import SafeData, mark_safe
 from django.utils.translation import ugettext_lazy
 
 import django_tables2 as tables
+import pytest
 
 from ..app.models import Person
 from ..utils import build_request, parse
@@ -349,7 +349,6 @@ def test_column_params_should_be_preserved_under_inheritance():
     '''
     class MyModel(models.Model):
         item1 = models.CharField(max_length=10)
-        item2 = models.CharField(max_length=10)
 
         class Meta:
             app_label = 'django_tables2_tests'
@@ -359,16 +358,28 @@ def test_column_params_should_be_preserved_under_inheritance():
 
         class Meta:
             model = MyModel
-            fields = ('item1',)
+            fields = ('item1', )
 
-    class MyTableExt(MyTable):
-        item2 = tables.Column()
+    class MyTableA(MyTable):
+        '''
+        having an empty `class Meta` should not undo the explicit definition
+        of column item1 in MyTable.
+        '''
+        class Meta(MyTable.Meta):
+            pass
 
-        # class Meta(MyTable.Meta):
-        #     fields = ('item1', 'item2')
+    class MyTableB(MyTable):
+        '''
+        having a non-empty `class Meta` should not undo the explicit definition
+        of column item1 in MyTable.
+        '''
+        class Meta(MyTable.Meta):
+            per_page = 22
 
     table = MyTable(MyModel.objects.all())
-    tableExt = MyTableExt(MyModel.objects.all())
+    tableA = MyTableA(MyModel.objects.all())
+    tableB = MyTableB(MyModel.objects.all())
 
     assert table.columns['item1'].verbose_name == 'Nice column name'
-    assert tableExt.columns['item1'].verbose_name == 'Nice column name'
+    assert tableA.columns['item1'].verbose_name == 'Nice column name'
+    assert tableB.columns['item1'].verbose_name == 'Nice column name'


### PR DESCRIPTION
Fixed by defining an `_explicit` attribute on tables which is set to `True` if a column is defined explicitly.

@nimch can you verify this fixes your issue? You can install using the zip github generates for each branch: 
```
pip install https://github.com/bradleyayers/django-tables2/archive/issue-337.zip
```