### PR TITLE
Use field name in RelatedColumnLink

### DIFF
--- a/django_tables2/columns/linkcolumn.py
+++ b/django_tables2/columns/linkcolumn.py
@@ -175,6 +175,6 @@ class RelatedLinkColumn(LinkColumn):
     '''
 
     def compose_url(self, record, bound_column):
-        accessor = self.accessor if self.accessor else Accessor(bound_column)
+        accessor = self.accessor if self.accessor else Accessor(bound_column.name)
 
         return accessor.resolve(record).get_absolute_url()

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -18,7 +18,7 @@ class Person(models.Model):
 
     occupation = models.ForeignKey(
         'Occupation', related_name='people',
-        null=True, verbose_name='occupation')
+        null=True, verbose_name='occupation of the person')
 
     trans_test = models.CharField(
         max_length=200, blank=True,


### PR DESCRIPTION
Default accessor was using the verbose name of a field instead of its name which caused resolution errors.

This should fix #347.