### PR TITLE
Refactor BoundColumn attributes to allow override of class names. #349

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -273,6 +273,8 @@ class TableOptions(object):
         self.template = getattr(options, 'template', 'django_tables2/table.html')
         self.localize = getattr(options, 'localize', ())
         self.unlocalize = getattr(options, 'unlocalize', ())
+        self.bound_column_class = getattr(options, 'bound_column_class',
+                                          columns.BoundColumn)
 
 
 class TableBase(object):

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -400,3 +400,31 @@ def test_explicit_column_can_be_overridden_by_other_explicit_column():
 
     assert table.columns['item1'].verbose_name == 'Nice column name'
     assert tableC.columns['item1'].verbose_name == 'New nice column name'
+
+
+def test_override_bound_column():
+    '''
+    We can override the class used for bound columns to control the
+    output of CSS class names
+    '''
+    class BoundColumnOverride(tables.columns.BoundColumn):
+        def get_class_name(self):
+            return 'prefix-' + self.name
+
+    class MyTable(tables.Table):
+        population = tables.Column(verbose_name='Population')
+
+        class Meta:
+            bound_column_class = BoundColumnOverride
+
+    TEST_DATA = [
+        {'name': 'Belgium', 'population': 11200000},
+        {'name': 'Luxembourgh', 'population': 540000},
+        {'name': 'France', 'population': 66000000},
+    ]
+
+    table = MyTable(TEST_DATA)
+    html = table.as_html(build_request())
+    print(html)
+
+    assert '<td class="prefix-population">11200000</td>' in html


### PR DESCRIPTION
Related issue: #349

First proposal, refactoring the BoundColumn code to allow override of the class names. For now this preserves the old behaviour of adding the column's name by default. See the test for how it can be overriddden. In a future version we could just swap the two `get_class_name` versions.

I'm not entirely happy with this, though. I think it would be better if users didn't have to touch the BoundColumn internals. I just couldn't think of a better place.

Maybe instead have a overridable `get_column_class_name(self, bound_column)` method directly on the table which would be called from BoundColumn, passing itself?