### PR TITLE
(Alt.) Refactor BoundColumn attributes to allow override of class names. #349

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -288,36 +288,36 @@ class BoundColumn(object):
         attrs['td'] = AttributeDict(attrs.get('td', attrs.get('cell', {})))
 
         # Override/add classes
-        attrs['th']['class'] = self.get_th_class_name(attrs['th'])
-        attrs['td']['class'] = self.get_td_class_name(attrs['td'])
+        attrs['th']['class'] = self.get_th_class(attrs['th'])
+        attrs['td']['class'] = self.get_td_class(attrs['td'])
 
         return attrs
 
-    def get_td_class_name(self, td_attrs):
+    def get_td_class(self, td_attrs):
         """
         Returns the HTML class attribute for a data cell in this column
         """
         classes = set((c for c in td_attrs.get('class', '').split(' ') if c))
-        td_classes = self.table.get_column_class_names(classes, self)
-        return ' '.join(sorted(td_classes))
+        classes = self.table.get_column_class_names(classes, self)
+        return ' '.join(sorted(classes))
 
-    def get_th_class_name(self, th_attrs):
+    def get_th_class(self, th_attrs):
         """
         Returns the HTML class attribute for a header cell in this column
         """
         classes = set((c for c in th_attrs.get('class', '').split(' ') if c))
-        th_classes = self.table.get_column_class_names(classes, self)
+        classes = self.table.get_column_class_names(classes, self)
 
         # add classes for ordering
         ordering_class = th_attrs.get('_ordering', {})
         if self.orderable:
-            th_classes.add(ordering_class.get('orderable', 'orderable'))
+            classes.add(ordering_class.get('orderable', 'orderable'))
         if self.is_ordered:
-            th_classes.add(ordering_class.get('descending', 'desc')
-                           if self.order_by_alias.is_descending
-                           else ordering_class.get('ascending', 'asc'))
+            classes.add(ordering_class.get('descending', 'desc')
+                        if self.order_by_alias.is_descending
+                        else ordering_class.get('ascending', 'asc'))
 
-        return ' '.join(sorted(th_classes))
+        return ' '.join(sorted(classes))
 
     @property
     def default(self):

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -293,37 +293,31 @@ class BoundColumn(object):
 
         return attrs
 
-    def get_class_name(self):
-        """
-        Returns the HTML class attribute used for both header and data cell
-        """
-        return self.name
-
     def get_td_class_name(self, td_attrs):
         """
         Returns the HTML class attribute for a data cell in this column
         """
-        td_class = set((c for c in td_attrs.get('class', '').split(' ') if c))
-        td_class.add(self.get_class_name())
-        return ' '.join(sorted(td_class))
+        classes = set((c for c in td_attrs.get('class', '').split(' ') if c))
+        td_classes = self.table.get_column_class_names(classes, self)
+        return ' '.join(sorted(td_classes))
 
     def get_th_class_name(self, th_attrs):
         """
         Returns the HTML class attribute for a header cell in this column
         """
-        th_class = set((c for c in th_attrs.get('class', '').split(' ') if c))
-        th_class.add(self.get_class_name())
+        classes = set((c for c in th_attrs.get('class', '').split(' ') if c))
+        th_classes = self.table.get_column_class_names(classes, self)
 
         # add classes for ordering
         ordering_class = th_attrs.get('_ordering', {})
         if self.orderable:
-            th_class.add(ordering_class.get('orderable', 'orderable'))
+            th_classes.add(ordering_class.get('orderable', 'orderable'))
         if self.is_ordered:
-            th_class.add(ordering_class.get('descending', 'desc')
-                         if self.order_by_alias.is_descending
-                         else ordering_class.get('ascending', 'asc'))
+            th_classes.add(ordering_class.get('descending', 'desc')
+                           if self.order_by_alias.is_descending
+                           else ordering_class.get('ascending', 'asc'))
 
-        return ' '.join(sorted(th_class))
+        return ' '.join(sorted(th_classes))
 
     @property
     def default(self):
@@ -509,9 +503,8 @@ class BoundColumns(object):
     def __init__(self, table):
         self.table = table
         self.columns = OrderedDict()
-        bc_class = getattr(self.table._meta, 'bound_column_class', BoundColumn)
         for name, column in six.iteritems(table.base_columns):
-            self.columns[name] = bc = bc_class(table, column, name)
+            self.columns[name] = bc = BoundColumn(table, column, name)
             bc.render = getattr(table, 'render_' + name, column.render)
             bc.order = getattr(table, 'order_' + name, column.order)
 

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -273,8 +273,6 @@ class TableOptions(object):
         self.template = getattr(options, 'template', 'django_tables2/table.html')
         self.localize = getattr(options, 'localize', ())
         self.unlocalize = getattr(options, 'unlocalize', ())
-        self.bound_column_class = getattr(options, 'bound_column_class',
-                                          columns.BoundColumn)
 
 
 class TableBase(object):
@@ -566,6 +564,24 @@ class TableBase(object):
     @template.setter
     def template(self, value):
         self._template = value
+
+    def get_column_class_names(self, classes_set, bound_column):
+        """
+        Returns a set of HTML class names for cells of a bound column
+        in this tables.
+        By default it uses the class names defined in the table's attributes,
+        and additionally the bound column's name.
+
+        Arguments:
+            classes_set(set of string): a set of class names to be added
+              to the cell, retrieved from the column's attributes
+
+            bound_column(`.BoundColumn`): the bound column the class names are
+              determined for
+        """
+        classes_set.add(bound_column.name)
+        return classes_set
+
 
 # Python 2/3 compatible way to enable the metaclass
 Table = DeclarativeColumnsMetaclass(str('Table'), (TableBase, ), {})

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -567,17 +567,25 @@ class TableBase(object):
 
     def get_column_class_names(self, classes_set, bound_column):
         """
-        Returns a set of HTML class names for cells of a bound column
-        in this tables.
-        By default it uses the class names defined in the table's attributes,
-        and additionally the bound column's name.
+        Returns a set of HTML class names for cells (both td and th) of a
+        **bound column** in this table.
+        By default this returns the column class names defined in the table's
+        attributes, and additionally the bound column's name.
+        This method can be overridden to change the default behavior, for
+        example to simply `return classes_set`.
 
         Arguments:
             classes_set(set of string): a set of class names to be added
-              to the cell, retrieved from the column's attributes
+              to the cell, retrieved from the column's attributes. In the case
+              of a header cell (th), this also includes ordering classes.
+              To set the classes for a column, see `.Column`.
+              To configure ordering classes, see :ref:`ordering-class-name`
 
             bound_column(`.BoundColumn`): the bound column the class names are
-              determined for
+              determined for. Useful for accessing `bound_column.name`.
+
+        Returns:
+            A set of class names to be added to cells of this column
         """
         classes_set.add(bound_column.name)
         return classes_set

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -273,6 +273,8 @@ class TableOptions(object):
         self.template = getattr(options, 'template', 'django_tables2/table.html')
         self.localize = getattr(options, 'localize', ())
         self.unlocalize = getattr(options, 'unlocalize', ())
+        self.bound_column_class = getattr(options, 'bound_column_class',
+                                          columns.BoundColumn)
 
 
 class TableBase(object):

--- a/docs/pages/api-reference.rst
+++ b/docs/pages/api-reference.rst
@@ -17,7 +17,7 @@ API Reference
 --------
 
 .. autoclass:: django_tables2.tables.Table
-    :members: paginate, as_html
+    :members: paginate, as_html, get_column_class_names
 
 
 `.Table.Meta`

--- a/docs/pages/column-headers-and-footers.rst
+++ b/docs/pages/column-headers-and-footers.rst
@@ -43,6 +43,8 @@ As you can see in the last example (region name), the results are not always
 desirable when an accessor is used to cross relationships. To get around this
 be careful to define `.Column.verbose_name`.
 
+.. _ordering-class-name:
+
 Changing class names for ordered column headers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -402,20 +402,17 @@ def test_explicit_column_can_be_overridden_by_other_explicit_column():
     assert tableC.columns['item1'].verbose_name == 'New nice column name'
 
 
-def test_override_bound_column():
+def test_override_column_class_names():
     '''
-    We can override the class used for bound columns to control the
-    output of CSS class names
+    We control the output of CSS class names for a column by overriding
+    get_column_class_names
     '''
-    class BoundColumnOverride(tables.columns.BoundColumn):
-        def get_class_name(self):
-            return 'prefix-' + self.name
-
     class MyTable(tables.Table):
         population = tables.Column(verbose_name='Population')
 
-        class Meta:
-            bound_column_class = BoundColumnOverride
+        def get_column_class_names(self, classes_set, bound_column):
+            classes_set.add('prefix-%s' % bound_column.name)
+            return classes_set
 
     TEST_DATA = [
         {'name': 'Belgium', 'population': 11200000},
@@ -425,6 +422,5 @@ def test_override_bound_column():
 
     table = MyTable(TEST_DATA)
     html = table.as_html(build_request())
-    print(html)
 
     assert '<td class="prefix-population">11200000</td>' in html

--- a/tests/columns/test_general.py
+++ b/tests/columns/test_general.py
@@ -400,3 +400,31 @@ def test_explicit_column_can_be_overridden_by_other_explicit_column():
 
     assert table.columns['item1'].verbose_name == 'Nice column name'
     assert tableC.columns['item1'].verbose_name == 'New nice column name'
+
+
+def test_override_bound_column():
+    '''
+    We can override the class used for bound columns to control the
+    output of CSS class names
+    '''
+    class BoundColumnOverride(tables.columns.BoundColumn):
+        def get_class_name(self):
+            return 'prefix-' + self.name
+
+    class MyTable(tables.Table):
+        population = tables.Column(verbose_name='Population')
+
+        class Meta:
+            bound_column_class = BoundColumnOverride
+
+    TEST_DATA = [
+        {'name': 'Belgium', 'population': 11200000},
+        {'name': 'Luxembourgh', 'population': 540000},
+        {'name': 'France', 'population': 66000000},
+    ]
+
+    table = MyTable(TEST_DATA)
+    html = table.as_html(build_request())
+    print(html)
+
+    assert '<td class="prefix-population">11200000</td>' in html


### PR DESCRIPTION
Related issue: #349
Original PR: #367

So now I added `Table.get_column_class_names` which gets the original set of class names (parsed from column attributes) as well as the bound column to replicate the old behavior but allow to override it.

This might still need a bit more documentation, I think.