### PR TITLE
Allow TableBase subclasses to render in template tag

### DIFF
--- a/django_tables2/__init__.py
+++ b/django_tables2/__init__.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from .tables import Table
+from .tables import Table, TableBase
 from .columns import (BooleanColumn, Column, CheckBoxColumn, DateColumn,
                       DateTimeColumn, EmailColumn, FileColumn, LinkColumn,
                       RelatedLinkColumn, TemplateColumn, TimeColumn, URLColumn)

--- a/django_tables2/templatetags/django_tables2.py
+++ b/django_tables2/templatetags/django_tables2.py
@@ -111,7 +111,7 @@ class RenderTableNode(Node):
     def render(self, context):
         table = self.table.resolve(context)
 
-        if isinstance(table, tables.Table):
+        if isinstance(table, tables.TableBase):
             pass
         elif hasattr(table, 'model'):
             queryset = table


### PR DESCRIPTION
When I subclassed TableBase to extend it and constructed it with DeclarativeColumnsMetaclass, it failed to render in the templatetag render function because it was not a tables.Table. This patch would allow a subclass of TableBase to pass the isinstance check and render properly, and still allow tables.Table instances to pass the check.