### PR TITLE
Titlise column verbose_name when derived from model

### DIFF
--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -441,13 +441,13 @@ class BoundColumn(object):
         Return the verbose name for this column.
 
         In order of preference, this will return:
-          1) The column's explicitly defined verbose_name
-          2) The titlised model's verbose name (if applicable)
+          1) The column's explicitly defined `verbose_name`
+          2) The titlised model's `verbose_name` (if applicable)
           3) Fallback to the titlised column name.
 
-        Any verbose_name that was not passed explicitly in the column
+        Any `verbose_name` that was not passed explicitly in the column
         definition is returned titlised in keeping with the Django convention
-        of verbose_names being defined in lowercase and uppercased/titlised
+        of `verbose_name` being defined in lowercase and uppercased/titlised
         as needed by the application.
 
         If the table is using queryset data, then use the corresponding model

--- a/django_tables2/columns/booleancolumn.py
+++ b/django_tables2/columns/booleancolumn.py
@@ -58,7 +58,8 @@ class BooleanColumn(Column):
 
     @classmethod
     def from_field(cls, field):
+        verbose_name = title(field.verbose_name)
         if isinstance(field, models.BooleanField):
-            return cls(verbose_name=title(field.verbose_name), null=False)
+            return cls(verbose_name=verbose_name, null=False)
         if isinstance(field, models.NullBooleanField):
-            return cls(verbose_name=title(field.verbose_name), null=True)
+            return cls(verbose_name=verbose_name, null=True)

--- a/django_tables2/columns/booleancolumn.py
+++ b/django_tables2/columns/booleancolumn.py
@@ -58,8 +58,7 @@ class BooleanColumn(Column):
 
     @classmethod
     def from_field(cls, field):
-        verbose_name = title(field.verbose_name)
         if isinstance(field, models.BooleanField):
-            return cls(verbose_name=verbose_name, null=False)
+            return cls(verbose_name=title(field.verbose_name), null=False)
         if isinstance(field, models.NullBooleanField):
-            return cls(verbose_name=verbose_name, null=True)
+            return cls(verbose_name=title(field.verbose_name), null=True)

--- a/django_tables2/columns/booleancolumn.py
+++ b/django_tables2/columns/booleancolumn.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.utils import six
 from django.utils.html import escape, format_html
 
+from django_tables2.templatetags.django_tables2 import title
 from django_tables2.utils import AttributeDict
 
 from .base import Column, library
@@ -58,6 +59,6 @@ class BooleanColumn(Column):
     @classmethod
     def from_field(cls, field):
         if isinstance(field, models.BooleanField):
-            return cls(verbose_name=field.verbose_name, null=False)
+            return cls(verbose_name=title(field.verbose_name), null=False)
         if isinstance(field, models.NullBooleanField):
-            return cls(verbose_name=field.verbose_name, null=True)
+            return cls(verbose_name=title(field.verbose_name), null=True)

--- a/django_tables2/columns/datecolumn.py
+++ b/django_tables2/columns/datecolumn.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 
+from django_tables2.templatetags.django_tables2 import title
+
 from .base import library
 from .templatecolumn import TemplateColumn
 
@@ -27,4 +29,4 @@ class DateColumn(TemplateColumn):
     @classmethod
     def from_field(cls, field):
         if isinstance(field, models.DateField):
-            return cls(verbose_name=field.verbose_name)
+            return cls(verbose_name=title(field.verbose_name))

--- a/django_tables2/columns/datetimecolumn.py
+++ b/django_tables2/columns/datetimecolumn.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 
+from django_tables2.templatetags.django_tables2 import title
+
 from .base import library
 from .templatecolumn import TemplateColumn
 
@@ -27,4 +29,4 @@ class DateTimeColumn(TemplateColumn):
     @classmethod
     def from_field(cls, field):
         if isinstance(field, models.DateTimeField):
-            return cls(verbose_name=field.verbose_name)
+            return cls(verbose_name=title(field.verbose_name))

--- a/django_tables2/columns/emailcolumn.py
+++ b/django_tables2/columns/emailcolumn.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 
+from django_tables2.templatetags.django_tables2 import title
+
 from .base import library
 from .linkcolumn import BaseLinkColumn
 
@@ -43,4 +45,4 @@ class EmailColumn(BaseLinkColumn):
     @classmethod
     def from_field(cls, field):
         if isinstance(field, models.EmailField):
-            return cls(verbose_name=field.verbose_name)
+            return cls(verbose_name=title(field.verbose_name))

--- a/django_tables2/columns/filecolumn.py
+++ b/django_tables2/columns/filecolumn.py
@@ -6,6 +6,7 @@ import os
 from django.db import models
 from django.utils.html import format_html
 
+from django_tables2.templatetags.django_tables2 import title
 from django_tables2.utils import AttributeDict
 
 from .base import library
@@ -84,4 +85,4 @@ class FileColumn(BaseLinkColumn):
     @classmethod
     def from_field(cls, field):
         if isinstance(field, models.FileField):
-            return cls(verbose_name=field.verbose_name)
+            return cls(verbose_name=title(field.verbose_name))

--- a/django_tables2/columns/timecolumn.py
+++ b/django_tables2/columns/timecolumn.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.db import models
 
+from django_tables2.templatetags.django_tables2 import title
+
 from .base import library
 from .templatecolumn import TemplateColumn
 
@@ -28,4 +30,4 @@ class TimeColumn(TemplateColumn):
     @classmethod
     def from_field(cls, field):
         if isinstance(field, models.TimeField):
-            return cls(verbose_name=field.verbose_name)
+            return cls(verbose_name=title(field.verbose_name))

--- a/django_tables2/columns/urlcolumn.py
+++ b/django_tables2/columns/urlcolumn.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 
+from django_tables2.templatetags.django_tables2 import title
+
 from .base import library
 from .linkcolumn import BaseLinkColumn
 
@@ -32,4 +34,4 @@ class URLColumn(BaseLinkColumn):
     @classmethod
     def from_field(cls, field):
         if isinstance(field, models.URLField):
-            return cls(verbose_name=field.verbose_name)
+            return cls(verbose_name=title(field.verbose_name))

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -31,6 +31,12 @@ class Person(models.Model):
     safe = models.CharField(
         max_length=200, blank=True, verbose_name=mark_safe("<b>Safe</b>"))
 
+    website = models.URLField(
+        max_length=200, null=True, blank=True,
+        verbose_name="web site")
+
+    birthdate = models.DateField(null=True)
+
     content_type = models.ForeignKey(ContentType, null=True, blank=True)
     object_id = models.PositiveIntegerField(null=True, blank=True)
     foreign_key = GenericForeignKey()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -100,6 +100,7 @@ def test_column_verbose_name():
         fn1 = tables.Column(accessor='first_name')
         fn2 = tables.Column(accessor='first_name.upper')
         fn3 = tables.Column(accessor='last_name', verbose_name='OVERRIDE')
+        fn4 = tables.Column(accessor='last_name', verbose_name='override')
         last_name = tables.Column()
         ln1 = tables.Column(accessor='last_name')
         ln2 = tables.Column(accessor='last_name.upper')
@@ -116,35 +117,42 @@ def test_column_verbose_name():
     # that we should expect that the two columns that use the ``last_name``
     # field should both use the model's ``last_name`` field's ``verbose_name``,
     # however both fields that use the ``first_name`` field should just use a
-    # capitalized version of the column name as the column header.
+    # titlised version of the column name as the column header.
     table = PersonTable(Person.objects.all())
     # Should be generated (capitalized column name)
-    assert 'first name' == table.columns['first_name'].verbose_name
-    assert 'first name' == table.columns['fn1'].verbose_name
-    assert 'first name' == table.columns['fn2'].verbose_name
+    assert 'First Name' == table.columns['first_name'].verbose_name
+    assert 'First Name' == table.columns['fn1'].verbose_name
+    assert 'First Name' == table.columns['fn2'].verbose_name
     assert 'OVERRIDE' == table.columns['fn3'].verbose_name
-    # Should use the model field's verbose_name
-    assert 'surname' == table.columns['last_name'].verbose_name
-    assert 'surname' == table.columns['ln1'].verbose_name
-    assert 'surname' == table.columns['ln2'].verbose_name
+    assert 'override' == table.columns['fn4'].verbose_name
+    # Should use the titlised model field's verbose_name
+    assert 'Surname' == table.columns['last_name'].verbose_name
+    assert 'Surname' == table.columns['ln1'].verbose_name
+    assert 'Surname' == table.columns['ln2'].verbose_name
     assert 'OVERRIDE' == table.columns['ln3'].verbose_name
-    assert 'name' == table.columns['region'].verbose_name
-    assert 'name' == table.columns['r1'].verbose_name
-    assert 'name' == table.columns['r2'].verbose_name
+    assert 'Name' == table.columns['region'].verbose_name
+    assert 'Name' == table.columns['r1'].verbose_name
+    assert 'Name' == table.columns['r2'].verbose_name
     assert 'OVERRIDE' == table.columns['r3'].verbose_name
-    assert "translation test" == table.columns["trans_test"].verbose_name
-    assert "translation test lazy" == table.columns["trans_test_lazy"].verbose_name
+    assert "Translation Test" == table.columns["trans_test"].verbose_name
+    assert "Translation Test Lazy" == table.columns["trans_test_lazy"].verbose_name
 
     # -------------------------------------------------------------------------
 
     # Now we'll try using a table with Meta.model
     class PersonTable(tables.Table):
+        first_name = tables.Column(verbose_name="OVERRIDE")
+
         class Meta:
             model = Person
+
     # Issue #16
     table = PersonTable([])
-    assert "translation test" == table.columns["trans_test"].verbose_name
-    assert "translation test lazy" == table.columns["trans_test_lazy"].verbose_name
+    assert "Translation Test" == table.columns["trans_test"].verbose_name
+    assert "Translation Test Lazy" == table.columns["trans_test_lazy"].verbose_name
+    assert "Web Site" == table.columns["website"].verbose_name
+    assert "Birthdate" == table.columns["birthdate"].verbose_name
+    assert "OVERRIDE" == table.columns["first_name"].verbose_name
 
 
 def test_data_verbose_name():

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -106,7 +106,7 @@ def test_render_table_supports_queryset():
                                     'request': build_request('/')}))
 
     root = parse(html)
-    assert [e.text for e in root.findall('.//thead/tr/th/a')] == ['ID', 'name', 'mayor']
+    assert [e.text for e in root.findall('.//thead/tr/th/a')] == ['ID', 'Name', 'Mayor']
     td = [[td.text for td in tr.findall('td')] for tr in root.findall('.//tbody/tr')]
     db = []
     for region in Region.objects.all():


### PR DESCRIPTION
This is my attempt at #249 and #368. If the verbose_name of a model is used to generate the verbose_name of the column, it is titlised. If the verbose_name is passed directly from a Column, it is used verbatim (see the test_column_verbose_name "override" tests). I updated the existing tests to reflect this change and added a couple new tests as well. If there's anything that I overlooked or need to change for this to be acceptable please let me know.