### PR TITLE
Deprecated usage of STATIC_URL

### DIFF
--- a/docs/pages/tutorial.rst
+++ b/docs/pages/tutorial.rst
@@ -32,10 +32,11 @@ Finally, implement the template::
 
     {# tutorial/templates/people.html #}
     {% load render_table from django_tables2 %}
+    {% load staticfiles %}
     <!doctype html>
     <html>
         <head>
-            <link rel="stylesheet" href="{{ STATIC_URL }}django_tables2/themes/paleblue/css/screen.css" />
+            <link rel="stylesheet" href="{% static 'django_tables2/themes/paleblue/css/screen.css' %}" />
         </head>
         <body>
             {% render_table people %}


### PR DESCRIPTION
According to the Django documentation and the attached article use of STATIC_URL creates trouble with some storages. It didn't work for me under 1.10.1 at all:
https://docs.djangoproject.com/en/1.10/howto/static-files/#configuring-static-files
http://staticfiles.productiondjango.com/blog/stop-using-static-url-in-templates/