### PR TITLE
Check for empty string on row_attrs['class']

### DIFF
--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -80,7 +80,7 @@ class BoundRow(object):
 
         row_attrs = computed_values(self._table.row_attrs, self._record)
 
-        if 'class' in row_attrs:
+        if 'class' in row_attrs and row_attrs['class']:
             row_attrs['class'] += ' ' + cssClass
         else:
             row_attrs['class'] = cssClass


### PR DESCRIPTION
Checking for an empty string on row_attrs['class'] allows you to assign the class attribute with a function that might return an empty string if the row doesn't meet the necessary criteria to get that particular css class.