### PR TITLE
Regression fix - revert commit 05d8d1d260fe1cfe61a89ef0ae09c78513022f3c

### DIFF
--- a/django_tables2/views.py
+++ b/django_tables2/views.py
@@ -92,6 +92,18 @@ class SingleTableMixin(TableMixinBase):
         elif hasattr(self, 'object_list'):
             return self.object_list
 
+        # it seems this is never going to happen because django wil raise
+        # ImproperlyConfigured if no model is defined and
+        # SingleTableMixin.get_table_class will raise if no table_data was specified...
+        # TODO: consider removing
+        elif hasattr(self, 'get_queryset'):
+            return self.get_queryset()
+
+        klass = type(self).__name__
+        raise ImproperlyConfigured(
+            'Table data was not specified. Define {}.table_data'.format(klass)
+        )
+
     def get_table_kwargs(self):
         '''
         Return the keyword arguments for instantiating the table.


### PR DESCRIPTION
I upgraded django_tables2 and an error occurs if I don't revert the commit which removes code which checks if there is a defined get_queryset method which is my case.