### PR TITLE
Made as_values method from TableBase an interator

### DIFF
--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -556,13 +556,13 @@ class TableBase(object):
 
     def as_values(self):
         '''
-        Return a 2d array of the data which would be shown in the table where the first row is the table headers.
+        Return a row iterator of the data which would be shown in the table where the first row is the table headers.
 
         This can be used to output the table data as CSV, excel, etc
         '''
-        headings = [str(c.header) for c in self.columns]
-        rows = [[r.get_cell_value(column.name) for column in r.table.columns] for r in self.rows]
-        return [headings] + rows
+        yield [str(c.header) for c in self.columns]
+        for r in self.rows:
+            yield [r.get_cell_value(column.name) for column in r.table.columns]
 
     def has_footer(self):
         '''

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -522,7 +522,7 @@ def test_as_values():
     expected = [['Name', 'Country']] + [[r['name'], r['country']] for r in data]
     table = Table(data)
 
-    assert table.as_values() == expected
+    assert list(table.as_values()) == expected
 
 
 def test_as_values_empty_values():
@@ -542,7 +542,7 @@ def test_as_values_empty_values():
     ]
     expected = [['Name', 'Country']] + [[r.get('name'), r.get('country')] for r in data]
     table = Table(data)
-    assert table.as_values() == expected
+    assert list(table.as_values()) == expected
 
 
 def test_row_attrs():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -421,4 +421,4 @@ def test_single_query_for_non_paginated_table():
     table = PersonTable(Person.objects.all())
 
     with assertNumQueries(1):
-        table.as_values()
+        list(table.as_values())


### PR DESCRIPTION
Previous as_values() method from TableBase returned a 2d array. I have queries with more than 500.000 items and it consumes too much memory for me.  The new implementation is based in yours but it returns an iterator of rows intead of a 2d array.
I think this is more versatile as you can create the previous 2d array just using list()

Tests are changed to fit with the new implementation.
 