### PR TITLE
Allow computable attrs for <td> from table.attrs 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,15 @@
 language: python
 
-# django 2.0 is only supported on py35+
-# django 1.9 is only supported on py27 and py35
-matrix:
-  include:
-    - { python: 2.7, env: TOXENV=py27-1.8 }
-    - { python: 2.7, env: TOXENV=py27-1.9 }
-    - { python: 2.7, env: TOXENV=py27-1.10 }
-    - { python: 2.7, env: TOXENV=py27-1.11 }
-    - { python: 3.3, env: TOXENV=py33-1.8 }
-    - { python: 3.4, env: TOXENV=py34-1.8 }
-    - { python: 3.4, env: TOXENV=py34-1.9 }
-    - { python: 3.4, env: TOXENV=py34-1.10 }
-    - { python: 3.4, env: TOXENV=py34-1.11 }
-    - { python: 3.4, env: TOXENV=py34-master }
-    - { python: 3.5, env: TOXENV=py35-1.8 }
-    - { python: 3.5, env: TOXENV=py35-1.9 }
-    - { python: 3.5, env: TOXENV=py35-1.10 }
-    - { python: 3.5, env: TOXENV=py35-1.11 }
-    - { python: 3.5, env: TOXENV=py35-master }
-    - { python: 3.6, env: TOXENV=py36-master }
-    - { python: 2.7, env: TOXENV=docs }
-
-  # we allow failures for versions which are not yet released:
-  allow_failures:
-      - env: TOXENV=py34-master
-      - env: TOXENV=py35-master
-      - env: TOXENV=py36-master
+python:
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "3.6"
 
 install:
-  - pip install tox
-  - pip install python-coveralls
+  - pip install tox-travis python-coveralls
+
 script:
   - tox
 

--- a/django_tables2/columns/base.py
+++ b/django_tables2/columns/base.py
@@ -304,10 +304,11 @@ class BoundColumn(object):
         cell_attrs = attrs.get('cell', {})
         # override with attrs defined specifically for th and td respectively.
         kwargs = {
-            'table': self._table
+            'table': self._table,
+            'column': self
         }
-        attrs['th'] = computed_values(attrs.get('th', cell_attrs), **kwargs)
-        attrs['td'] = computed_values(attrs.get('td', cell_attrs), **kwargs)
+        attrs['th'] = computed_values(attrs.get('th', cell_attrs), kwargs=kwargs)
+        attrs['td'] = computed_values(attrs.get('td', cell_attrs), kwargs=kwargs)
 
         # wrap in AttributeDict
         attrs['th'] = AttributeDict(attrs['th'])

--- a/django_tables2/rows.py
+++ b/django_tables2/rows.py
@@ -87,7 +87,7 @@ class BoundRow(object):
         '''
         cssClass = self.get_even_odd_css_class()
 
-        row_attrs = computed_values(self._table.row_attrs, self._record)
+        row_attrs = computed_values(self._table.row_attrs, kwargs={'record': self._record})
 
         if 'class' in row_attrs and row_attrs['class']:
             row_attrs['class'] += ' ' + cssClass
@@ -244,7 +244,7 @@ class BoundPinnedRow(BoundRow):
         Return:
             AttributeDict: Attributes for pinned rows.
         '''
-        row_attrs = computed_values(self._table.pinned_row_attrs, self._record)
+        row_attrs = computed_values(self._table.pinned_row_attrs, kwargs={'record': self._record})
         css_class = ' '.join([
             self.get_even_odd_css_class(),
             'pinned-row',

--- a/django_tables2/tables.py
+++ b/django_tables2/tables.py
@@ -232,8 +232,8 @@ class TableBase(object):
         }
 
         self.rows = BoundRows(data=self.data, table=self, pinned_data=self.pinned_data)
-        attrs = computed_values(attrs if attrs is not None else self._meta.attrs)
-        self.attrs = AttributeDict(attrs)
+        self.attrs = AttributeDict(attrs if attrs is not None else self._meta.attrs)
+
         self.row_attrs = AttributeDict(row_attrs or self._meta.row_attrs)
         self.empty_text = empty_text if empty_text is not None else self._meta.empty_text
         self.orderable = orderable

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@
 Sphinx==1.6.2
 sphinx_rtd_theme
 recommonmark
+tablib

--- a/requirements/django-dev.pip
+++ b/requirements/django-dev.pip
@@ -1,2 +1,3 @@
 -r common.pip
+Django==1.11.2
 https://github.com/django/django/archive/1.11a1.zip

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 import django_tables2 as tables
 from django_tables2.tables import DeclarativeColumnsMetaclass
 
-from .utils import build_request, parse, attrs
+from .utils import build_request, parse
 
 request = build_request('/')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 import django_tables2 as tables
 from django_tables2.tables import DeclarativeColumnsMetaclass
 
-from .utils import build_request
+from .utils import build_request, parse, attrs
 
 request = build_request('/')
 
@@ -596,5 +596,8 @@ def test_td_attrs_from_table():
             }
     table = Table(MEMORY_DATA)
     html = table.as_html(request)
-
-    assert '<td data-column-name="alpha" class="alpha">' in html
+    td = parse(html).find('.//tbody/tr[1]/td[1]')
+    assert td.attrib == {
+        'data-column-name': 'alpha',
+        'class': 'alpha'
+    }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -146,8 +146,8 @@ def test_attrs_support_computed_values():
         class Meta:
             attrs = {'id': lambda: 'test_table_%d' % next(counter)}
 
-    assert {'id': 'test_table_0'} == TestTable([]).attrs
-    assert {'id': 'test_table_1'} == TestTable([]).attrs
+    assert 'id="test_table_0"' == TestTable([]).attrs.as_html()
+    assert 'id="test_table_1"' == TestTable([]).attrs.as_html()
 
 
 def test_attrs_from_settings(settings):
@@ -581,3 +581,20 @@ def test_row_attrs_in_meta():
 
     table = Table(MEMORY_DATA)
     assert table.rows[0].attrs == {'class': 'row-id-2 even'}
+
+
+def test_td_attrs_from_table():
+    class Table(tables.Table):
+        alpha = tables.Column()
+        beta = tables.Column()
+
+        class Meta:
+            attrs = {
+                'td': {
+                    'data-column-name': lambda column: column.name
+                }
+            }
+    table = Table(MEMORY_DATA)
+    html = table.as_html(request)
+
+    assert '<td data-column-name="alpha" class="alpha">' in html

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -70,7 +70,7 @@ def test_row_attrs():
 
         class Meta(object):
             row_attrs = {
-                'class': lambda x: '' if next(counter) % 2 == 0 else 'bla'
+                'class': lambda: '' if next(counter) % 2 == 0 else 'bla'
             }
 
     table = Table([

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,7 +158,6 @@ def test_accessor_penultimate():
 
 def test_attribute_dict_handles_escaping():
     x = AttributeDict({'x': '"\'x&'})
-    print x
     assert x.as_html() == 'x="&quot;&#39;x&amp;"'
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,6 +158,7 @@ def test_accessor_penultimate():
 
 def test_attribute_dict_handles_escaping():
     x = AttributeDict({'x': '"\'x&'})
+    print x
     assert x.as_html() == 'x="&quot;&#39;x&amp;"'
 
 
@@ -176,7 +177,7 @@ def test_computed_values_with_argument():
         'foo': lambda y: {
             'bar': lambda y: 'baz-{}'.format(y)
         }
-    }, y=2)
+    }, kwargs=dict(y=2))
     assert x == {'foo': {'bar': 'baz-2'}}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,7 @@ envlist =
     {py27,py33,py34}-{1.8},
     {py27,py34,py35}-{1.9,1.10,1.11},
     {py34,py35,py36}-{master},
-    docs
-    flake8
-    isort
+    py27-{docs,flake8,isort}
 
 [testenv]
 basepython =
@@ -34,7 +32,7 @@ deps =
     psycopg2
     -r{toxinidir}/requirements/common.pip
 
-[testenv:docs]
+[testenv:py27-docs]
 whitelist_externals = make
 changedir = docs
 commands = make html
@@ -42,8 +40,8 @@ basepython = python2.7
 deps =
     -r{toxinidir}/docs/requirements.txt
 
-[testenv:flake8]
-basepython = python3.6
+[testenv:py27-flake8]
+basepython = python2.7
 deps = flake8
 commands = flake8
 
@@ -51,7 +49,7 @@ commands = flake8
 ignore = F401,E731
 max-line-length = 120
 
-[testenv:isort]
+[testenv:py27-isort]
 deps = isort==4.2.15
-basepython = python3.6
+basepython = python2.7
 commands = isort --diff --check --recursive {toxinidir}/django_tables2 {toxinidir}/tests {toxinidir}/example


### PR DESCRIPTION
It was already possible to use the `attrs`-argument like this:

```python
class Table(tables.Table):
    class Meta:
        attrs = {
           'td': {'class': 'foo'}
        }
```

But it did not pass any relevant arguments to callables. This PR changes that and passes `column` and `table` keyword arguments if appropriate:

```python
class Table(tables.Table):
    class Meta:
        attrs = {
           'td': {'data-name': lambda column: column.name}
        }
```

Fixes #451 
